### PR TITLE
기존 사용자 등록 시 아이디를 반환

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import java.net.http.HttpResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpEntity;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -5,7 +5,6 @@ import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.domain.exhibit.ExhibitContents;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
-import com.yapp.artie.domain.archive.exception.CategoryNotFoundException;
 import com.yapp.artie.domain.archive.exception.ExhibitNotFoundException;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfCategoryException;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfExhibitException;

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.yapp.artie.domain.user.controller;
 import com.google.firebase.auth.FirebaseToken;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
-import com.yapp.artie.domain.user.exception.UserAlreadyExistException;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.service.UserService;
 import com.yapp.artie.global.authentication.JwtService;

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -45,7 +45,6 @@ public class UserController {
     String authorization = request.getHeader("Authorization");
     FirebaseToken decodedToken = jwtService.verify(authorization);
     validateUidWithToken(uid, decodedToken);
-    validateDuplicateUser(uid);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(
         userService.register(decodedToken.getUid(), decodedToken.getName(),
@@ -72,11 +71,5 @@ public class UserController {
     if (!decodedToken.getUid().equals(uid)) {
       throw new InvalidValueException();
     }
-  }
-
-  private void validateDuplicateUser(String uid) {
-    userService.findByUid(uid).ifPresent((existedUser) -> {
-      throw new UserAlreadyExistException();
-    });
   }
 }

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import static org.springframework.security.core.userdetails.User.builder;
 
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
+import com.yapp.artie.domain.user.exception.UserAlreadyExistException;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.repository.UserRepository;
 import java.util.Optional;
@@ -30,8 +31,13 @@ public class UserService implements UserDetailsService {
 
   @Transactional
   public CreateUserResponseDto register(String uid, String username, String picture) {
-    User user = User.create(uid, username, picture);
-    userRepository.save(user);
+    User user = findByUid(uid)
+        .orElse(User.create(uid, username, picture));
+
+    if (user.getId() == null) {
+      userRepository.save(user);
+    }
+
     return new CreateUserResponseDto(user.getId());
   }
 

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ import static org.springframework.security.core.userdetails.User.builder;
 
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
-import com.yapp.artie.domain.user.exception.UserAlreadyExistException;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.repository.UserRepository;
 import java.util.Optional;

--- a/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
+++ b/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
@@ -1,7 +1,6 @@
 package com.yapp.artie.global.exception.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import lombok.Getter;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)


### PR DESCRIPTION
# 구현 내용

## 구현 요약

기존 회원가입된 유저가 다시 회원가입할 경우 예외를 던지게 구현했는데, 이미 회원가입된 유저가 다시 회원가입한다면,
id를 반환하도록 기능 수정

## 관련 이슈

close #14 

## 구현 내용

- [ ] 회원가입 재요청시 id 반환하도록 기능 수정



