### PR TITLE
전시 테스트와 리팩터링

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
@@ -3,7 +3,6 @@ package com.yapp.artie.domain.archive.domain.exhibit;
 
 import com.yapp.artie.domain.archive.domain.artwork.Artwork;
 import com.yapp.artie.domain.archive.domain.category.Category;
-import com.yapp.artie.domain.archive.exception.ExhibitAlreadyPublishedException;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.global.common.BaseEntity;
 import java.time.LocalDate;
@@ -75,10 +74,6 @@ public class Exhibit extends BaseEntity {
   }
 
   public void publish() {
-    if (isPublished()) {
-      throw new ExhibitAlreadyPublishedException();
-    }
-
     publication.publish();
   }
 

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Publication.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Publication.java
@@ -1,5 +1,6 @@
 package com.yapp.artie.domain.archive.domain.exhibit;
 
+import com.yapp.artie.domain.archive.exception.ExhibitAlreadyPublishedException;
 import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -20,6 +21,10 @@ public class Publication {
   private LocalDate publishedAt;
 
   public void publish() {
+    if (isPublished) {
+      throw new ExhibitAlreadyPublishedException();
+    }
+
     this.isPublished = true;
     this.publishedAt = LocalDate.now();
   }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
@@ -19,7 +19,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   @Modifying(clearAutomatically = true)
   @Query("update Category c set c.sequence = c.sequence - 1 where c.sequence > :sequence and c.user = :user")
-  int bulkSequenceMinus(@Param("user") User user, @Param("sequence") int sequence);
+  void bulkSequenceMinus(@Param("user") User user, @Param("sequence") int sequence);
 
   @EntityGraph(attributePaths = {"user"})
   Category findCategoryEntityGraphById(Long id);

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -23,7 +23,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   @Query("select new com.yapp.artie.domain.archive.dto.exhibit."
       + "PostInfoDto(e.id, e.contents.name, e.contents.date, e.publication.isPublished) "
       + "from Exhibit e where e.user = :user and e.publication.isPublished = false")
-  List<PostInfoDto> findExhibitDto(@Param("user") User user);
+  List<PostInfoDto> findDraftExhibitDto(@Param("user") User user);
 
 
   @Query(

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -2,10 +2,10 @@ package com.yapp.artie.domain.archive.repository;
 
 import com.yapp.artie.domain.archive.domain.category.Category;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
-import java.util.Optional;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.user.domain.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;

--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -45,7 +45,6 @@ public class ArtworkService {
   }
 
   private User findUser(Long userId) {
-    return userService.findById(userId)
-        .orElseThrow(UserNotFoundException::new);
+    return userService.findById(userId);
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
@@ -30,9 +30,13 @@ public class CategoryService {
   private final String DEFAULT_CATEGORY_NAME = "전체 기록";
   private final int CATEGORY_LIMIT_COUNT = 5;
 
-  public Category findCategoryWithUser(Long id) {
-    return Optional.ofNullable(categoryRepository.findCategoryEntityGraphById(id))
+  public Category findCategoryWithUser(Long id, Long userId) {
+    Category category = Optional.ofNullable(categoryRepository.findCategoryEntityGraphById(id))
         .orElseThrow(CategoryNotFoundException::new);
+    User user = findUser(userId);
+    validateOwnedByUser(category, user);
+
+    return category;
   }
 
   public List<CategoryDto> categoriesOf(Long userId) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
@@ -12,7 +12,6 @@ import com.yapp.artie.domain.archive.exception.ExceededCategoryCountException;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfCategoryException;
 import com.yapp.artie.domain.archive.repository.CategoryRepository;
 import com.yapp.artie.domain.user.domain.User;
-import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.service.UserService;
 import java.util.List;
 import java.util.Optional;
@@ -110,8 +109,7 @@ public class CategoryService {
   }
 
   private User findUser(Long userId) {
-    return userService.findById(userId)
-        .orElseThrow(UserNotFoundException::new);
+    return userService.findById(userId);
   }
 
   private void validateExistAtLeastOneCategory(List<CategoryDto> categories) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -89,7 +89,7 @@ public class ExhibitService {
     User user = findUser(userId);
     Exhibit exhibit = exhibitRepository.findExhibitEntityGraphById(id)
         .orElseThrow(ExhibitNotFoundException::new);
-    ;
+
     validate(user, exhibit);
 
     exhibit.update(updateExhibitRequestDto.getName(), updateExhibitRequestDto.getPostDate());

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -33,7 +33,7 @@ public class ExhibitService {
     User user = findUser(userId);
     Exhibit exhibit = exhibitRepository.findExhibitEntityGraphById(id)
         .orElseThrow(ExhibitNotFoundException::new);
-    validate(user, exhibit);
+    validateOwnedByUser(user, exhibit);
 
     ExhibitContents contents = exhibit.contents();
     return new PostInfoDto(exhibit.getId(), contents.getName(),
@@ -79,7 +79,7 @@ public class ExhibitService {
     User user = findUser(userId);
     Exhibit exhibit = exhibitRepository.findExhibitEntityGraphById(id)
         .orElseThrow(ExhibitNotFoundException::new);
-    validate(user, exhibit);
+    validateOwnedByUser(user, exhibit);
 
     exhibit.publish();
   }
@@ -89,8 +89,7 @@ public class ExhibitService {
     User user = findUser(userId);
     Exhibit exhibit = exhibitRepository.findExhibitEntityGraphById(id)
         .orElseThrow(ExhibitNotFoundException::new);
-
-    validate(user, exhibit);
+    validateOwnedByUser(user, exhibit);
 
     exhibit.update(updateExhibitRequestDto.getName(), updateExhibitRequestDto.getPostDate());
   }
@@ -100,18 +99,7 @@ public class ExhibitService {
         .orElseThrow(UserNotFoundException::new);
   }
 
-  private void validate(User user, Exhibit exhibit) {
-    validateExhibitFound(exhibit);
-    validateOwnedByUser(exhibit, user);
-  }
-
-  private void validateExhibitFound(Exhibit exhibit) {
-    if (exhibit == null) {
-      throw new ExhibitNotFoundException();
-    }
-  }
-
-  private void validateOwnedByUser(Exhibit exhibit, User user) {
+  private void validateOwnedByUser(User user, Exhibit exhibit) {
     if (!exhibit.ownedBy(user)) {
       throw new NotOwnerOfExhibitException();
     }

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -9,7 +9,6 @@ import com.yapp.artie.domain.archive.exception.ExhibitNotFoundException;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfExhibitException;
 import com.yapp.artie.domain.archive.repository.ExhibitRepository;
 import com.yapp.artie.domain.user.domain.User;
-import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -75,8 +74,7 @@ public class ExhibitService {
   }
 
   private User findUser(Long userId) {
-    return userService.findById(userId)
-        .orElseThrow(UserNotFoundException::new);
+    return userService.findById(userId);
   }
 
   private void validateOwnedByUser(User user, Exhibit exhibit) {

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.yapp.artie.domain.user.controller;
 import com.google.firebase.auth.FirebaseToken;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
-import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.service.UserService;
 import com.yapp.artie.global.authentication.JwtService;
 import com.yapp.artie.global.exception.common.InvalidValueException;
@@ -60,8 +59,7 @@ public class UserController {
   })
   @GetMapping("/me")
   public ResponseEntity<User> me(Authentication authentication) {
-    User user = userService.findById((Long.parseLong(authentication.getName())))
-        .orElseThrow(UserNotFoundException::new);
+    User user = userService.findById((Long.parseLong(authentication.getName())));
 
     return ResponseEntity.ok().body(user);
   }

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -24,8 +24,8 @@ public class UserService implements UserDetailsService {
     return userRepository.findByUid(uid);
   }
 
-  public Optional<User> findById(Long id) {
-    return userRepository.findById(id);
+  public User findById(Long id) {
+    return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
   }
 
   @Transactional

--- a/src/test/java/com/yapp/artie/domain/archive/service/CategoryServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/CategoryServiceTest.java
@@ -63,7 +63,7 @@ class CategoryServiceTest {
   public void findCategoryWithUser_해당_id의_카테고리가_존재하지_않으면_예외를_발생한다() throws Exception {
     User user = userRepository.findByUid("tu1").get();
     assertThatThrownBy(() -> {
-      categoryService.findCategoryWithUser(1L);
+      categoryService.findCategoryWithUser(1L, user.getId());
     }).isInstanceOf(CategoryNotFoundException.class);
   }
 
@@ -72,7 +72,7 @@ class CategoryServiceTest {
     User user = userRepository.findByUid("tu1").get();
     CreateCategoryRequestDto createCategoryRequestDto = new CreateCategoryRequestDto("test");
     Long created = categoryService.create(createCategoryRequestDto, user.getId());
-    Category categoryWithUser = categoryService.findCategoryWithUser(created);
+    Category categoryWithUser = categoryService.findCategoryWithUser(created, user.getId());
     assertThat(emf.getPersistenceUnitUtil().isLoaded(categoryWithUser.getUser())).isTrue();
   }
 

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -1,6 +1,13 @@
 package com.yapp.artie.domain.archive.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
+import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.Test;
@@ -24,14 +31,29 @@ class ExhibitServiceTest {
   @Autowired
   ExhibitService exhibitService;
 
+  @Autowired
+  CategoryService categoryService;
+
+  User createUser() {
+    User user = new User();
+    user.setName("test");
+    user.setUid("tu1");
+    em.persist(user);
+    categoryService.createDefault(user.getId());
+
+    return user;
+  }
 
   @Test
-  public void test() throws Exception {
-    //given
+  public void create_전시를_생성한다() throws Exception {
+    User user = createUser();
+    CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test", 1L,
+        LocalDate.now());
 
-    //when
+    exhibitService.create(exhibitRequestDto, user.getId());
+    Optional<Exhibit> exhibit = Optional.ofNullable(em.find(Exhibit.class, 1L));
 
-    //then
+    assertThat(exhibit).isPresent();
   }
 
 }

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.dto.cateogry.CategoryDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
+import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
+import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.exception.ExhibitAlreadyPublishedException;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfCategoryException;
 import com.yapp.artie.domain.user.domain.User;
@@ -106,6 +108,27 @@ class ExhibitServiceTest {
     assertThatThrownBy(() -> {
       exhibitService.publish(exhibit.getId(), user.getId());
     }).isInstanceOf(ExhibitAlreadyPublishedException.class);
+  }
+
+  @Test
+  public void update_전시를_수정한다() throws Exception {
+    User user = createUser("user", "tu");
+    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
+        defaultCateogry.getId(),
+        LocalDate.now());
+    Long created = exhibitService.create(exhibitRequestDto, user.getId());
+    exhibitService.publish(created, user.getId());
+    Exhibit exhibit = em.find(Exhibit.class, created);
+
+    String updatedName = "rename";
+    exhibitService.update(new UpdateExhibitRequestDto(updatedName, LocalDate.now()),
+        exhibit.getId(),
+        user.getId());
+
+    PostInfoDto actual = exhibitService.getExhibitInformation(exhibit.getId(),
+        user.getId());
+    assertThat(actual.getName()).isEqualTo(updatedName);
   }
 }
 

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -1,0 +1,37 @@
+package com.yapp.artie.domain.archive.service;
+
+import com.yapp.artie.domain.user.repository.UserRepository;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class ExhibitServiceTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  EntityManagerFactory emf;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  ExhibitService exhibitService;
+
+
+  @Test
+  public void test() throws Exception {
+    //given
+
+    //when
+
+    //then
+  }
+
+}

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -73,5 +73,20 @@ class ExhibitServiceTest {
       exhibitService.create(exhibitRequestDto, userAnother.getId());
     }).isInstanceOf(NotOwnerOfCategoryException.class);
   }
+
+  @Test
+  public void publish_임시저장된_전시를_영구저장한다() throws Exception {
+    User user = createUser("user", "tu");
+    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
+        defaultCateogry.getId(),
+        LocalDate.now());
+
+    Long created = exhibitService.create(exhibitRequestDto, user.getId());
+    exhibitService.publish(created, user.getId());
+    Exhibit exhibit = em.find(Exhibit.class, created);
+
+    assertThat(exhibit.isPublished()).isTrue();
+  }
 }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

전시 테스트 작성 및 전시 서비스 리팩토링

## 관련 이슈

close #21 

## 구현 내용

- [ x] 전시 테스트 코드 작성
- [ x] userService#findById 내부로 예외 처리 로직 이동
- [ x] 전시 발행 기능, 예외 처리를 발행 객체 내부로 캡슐화
- [ x] 전시 서비스 메서드 추출, 메서드 이동 




