### PR TITLE
이미지 업로드 Presigned URL 발급 후 업로드 에러 버그 개선

### DIFF
--- a/src/main/java/com/yapp/artie/domain/s3/controller/S3Controller.java
+++ b/src/main/java/com/yapp/artie/domain/s3/controller/S3Controller.java
@@ -60,11 +60,13 @@ public class S3Controller {
       @RequestParam(required = true, value = "id") Long postId) {
     Long userId = Long.parseLong(authentication.getName());
     userService.findById(userId);
+
     AtomicInteger index = new AtomicInteger(1);
     List<presignedUrlDataDto> urlDataList = getPresignedUrlRequestDto.getImageNames()
         .stream().map(imageName -> s3Service.getPresignedUrl(imageName, postId,
             index.getAndIncrement())).filter(url -> url.isPresent()).filter(Optional::isPresent)
         .map(Optional::get).collect(Collectors.toList());
+    
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(new GetPresignedUrlResponseDto(urlDataList));
   }

--- a/src/main/java/com/yapp/artie/global/util/S3Utils.java
+++ b/src/main/java/com/yapp/artie/global/util/S3Utils.java
@@ -2,6 +2,8 @@ package com.yapp.artie.global.util;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +25,10 @@ public class S3Utils {
   public String generatePresignedUrl(String objectKey, long expirationMin) {
     GeneratePresignedUrlRequest generatePresignedUrlRequest =
         new GeneratePresignedUrlRequest(bucketName, objectKey)
-            .withMethod(HttpMethod.GET)
+            .withMethod(HttpMethod.PUT)
             .withExpiration(convertExpirationMinIntoDate(expirationMin));
+    generatePresignedUrlRequest.addRequestParameter(Headers.S3_CANNED_ACL,
+        CannedAccessControlList.Private.toString());
     return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest).toString();
   }
 

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -4,7 +4,7 @@ cloud:
       secret-key: ${AWS_SECRET_ACCESS_KEY}
       access-key: ${AWS_ACCESS_KEY_ID}
     s3:
-      bucket: ${AWS_S3_BUCKET}/${profile}
+      bucket: ${AWS_S3_BUCKET}
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 이미지 업로드 Presigned URL 발급 후 업로드 에러 버그 개선
- 다양한 시도 끝에, GeneratePresignedUrlRequest에 withContentsType을 설정해서는 안되며, 업로드시에는 PUT 메소드를 써야하고, 많은 스택오버플로우의 SignatureDoesNotMatch 에러시 해결법으로 제공되는 Secret Key의 특수문자 제거나 새로운 IAM Key 발급은 의미없는 해결방법임을 꺠달음
- 기타 가독성을 위한 /n 추가

## 관련 이슈

close #30 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




