### PR TITLE
전시 상세정보 API, 작품 목록 API 개발 및 일부 Swagger 값 수정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -73,7 +73,9 @@ jobs:
         env:
           cloud.aws.credentials.access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           cloud.aws.credentials.secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          cloud.aws.s3.bucket: ${{ secrets.AWS_S3_BUCKET }}/prod
+          cloud.aws.s3.bucket: ${{ secrets.AWS_S3_BUCKET }}
+          cloud.aws.cloudfront.domain: ${{ secrets.AWS_CDN_DOMAIN }}
+
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 docker/.dbdata
 
 firebase.json
+.DS_Store

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -3,10 +3,14 @@ package com.yapp.artie.domain.archive.controller;
 
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitResponseDto;
+import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.service.ExhibitService;
+import com.yapp.artie.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -139,5 +143,40 @@ public class ExhibitController {
     Long userId = Long.parseLong(authentication.getName());
     exhibitService.publish(id, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "전시 상세 정보 조회", description = "전시 상세 페이지 내 전시 상세 정보 조회. 카테고리 정보, 대표이미지 정보를 포함함.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "전시 상세 정보 반환",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostDetailInfo.class))),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 입력",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증 오류",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "403",
+          description = "접근 불가능한 전시",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 회원",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 전시",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+  })
+  @GetMapping("/detail/{id}")
+  public ResponseEntity<PostDetailInfo> getPostInfoWithCategory(
+      Authentication authentication,
+      @Parameter(name = "id", description = "전시 ID", in = ParameterIn.PATH) @PathVariable("id") Long id) {
+    Long userId = Long.parseLong(authentication.getName());
+    return ResponseEntity.ok().body(exhibitService.getDetailExhibitInformation(id, userId));
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpEntity;
 import org.springframework.data.domain.Page;
@@ -175,7 +176,7 @@ public class ExhibitController {
   @GetMapping("/detail/{id}")
   public ResponseEntity<PostDetailInfo> getPostInfoWithCategory(
       Authentication authentication,
-      @Parameter(name = "id", description = "전시 ID", in = ParameterIn.PATH) @PathVariable("id") Long id) {
+      @Parameter(name = "id", description = "전시 ID", in = ParameterIn.PATH) @Valid @PathVariable("id") Long id) {
     Long userId = Long.parseLong(authentication.getName());
     return ResponseEntity.ok().body(exhibitService.getDetailExhibitInformation(id, userId));
   }

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
@@ -61,6 +61,10 @@ public class Exhibit extends BaseEntity {
     return id;
   }
 
+  public Category getCategory() {
+    return category;
+  }
+
   public void categorize(Category category) {
     this.category = category;
   }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/ArtworkThumbnailDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/ArtworkThumbnailDto.java
@@ -1,0 +1,39 @@
+package com.yapp.artie.domain.archive.dto.artwork;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@Schema(description = "작품 목록의 작품 썸네일 정보")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArtworkThumbnailDto {
+
+  @NonNull
+  @Schema(description = "작품 ID", required = true)
+  private Long id;
+
+  @NonNull
+  @Schema(description = "작품 이미지", required = true)
+  private String imageURL;
+
+  @NonNull
+  @Schema(description = "작품명", required = true, defaultValue = "작품명 미입력")
+  private String name;
+
+  @NonNull
+  @Schema(description = "관람 날짜", required = true, defaultValue = "작가명 미입력")
+  private String artist;
+
+  @Builder
+  public ArtworkThumbnailDto(@NonNull Long id, @NonNull String imageURL, String name,
+      String artist) {
+    this.id = id;
+    this.imageURL = imageURL;
+    this.name = name == null ? "작품명 미입력" : name;
+    this.artist = artist == null ? "작품명 미입력" : artist;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/ArtworkThumbnailDtoPage.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/ArtworkThumbnailDtoPage.java
@@ -1,0 +1,13 @@
+package com.yapp.artie.domain.archive.dto.artwork;
+
+import java.util.List;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class ArtworkThumbnailDtoPage extends PageImpl<ArtworkThumbnailDto> {
+
+  public ArtworkThumbnailDtoPage(List<ArtworkThumbnailDto> content,
+      Pageable pageable, long total) {
+    super(content, pageable, total);
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkRequestDto.java
@@ -24,7 +24,7 @@ public class CreateArtworkRequestDto {
 
   @NotNull
   @NotBlank
-  @Schema(description = "s3 이미지 URI")
+  @Schema(description = "s3 이미지 URI. S3 Presigned URL 발급 후 반환한 imageKey 값")
   private String imageUri;
 
   @Schema(description = "작가 이름")

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfo.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfo.java
@@ -1,0 +1,54 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@Schema(description = "전시 Response")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostDetailInfo {
+
+  @NonNull
+  @Schema(description = "전시 아이디", required = true)
+  private Long id;
+
+  @NonNull
+  @Schema(description = "전시명", required = true)
+  private String name;
+
+  @NonNull
+  @Schema(description = "관람 날짜", required = true)
+  private LocalDate postDate;
+
+  @Schema(description = "임시 저장 여부")
+  private boolean isPublished;
+
+  @NonNull
+  @Schema(description = "카테고리 아이디", required = true)
+  private Long categoryId;
+
+  @NonNull
+  @Schema(description = "카테고리 명", required = true)
+  private String categoryName;
+
+  @Schema(description = "대표 이미지")
+  private String mainImage;
+
+  @Builder
+  public PostDetailInfo(@NonNull Long id, @NonNull String name, @NonNull LocalDate postDate,
+      boolean isPublished, @NonNull Long categoryId, @NonNull String categoryName,
+      String mainImage) {
+    this.id = id;
+    this.name = name;
+    this.postDate = postDate;
+    this.isPublished = isPublished;
+    this.categoryId = categoryId;
+    this.categoryName = categoryName;
+    this.mainImage = mainImage;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/tag/CreateArtworkTagDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/tag/CreateArtworkTagDto.java
@@ -11,11 +11,11 @@ import lombok.Getter;
 public class CreateArtworkTagDto {
 
   @Positive
-  @Schema(description = "태그 ID")
+  @Schema(description = "태그 ID. 기존에 존재한 태그를 작품에 추가할 경우 제공되어야함.")
   private Long tagId;
 
   @NotNull
   @NotBlank
-  @Schema(description = "태그 이름")
+  @Schema(description = "태그 이름. 새롭게 태그를 생성하여 작품에 추가할 경우 태그 이름만 제공되어야함.")
   private String tagName;
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ArtworkRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ArtworkRepository.java
@@ -1,11 +1,20 @@
 package com.yapp.artie.domain.archive.repository;
 
 import com.yapp.artie.domain.archive.domain.artwork.Artwork;
+import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
 
   Long countArtworkByExhibitId(Long id);
+
+  @Query(
+      "select e from Artwork e where e.exhibit = :exhibit and e.isMain = true "
+  )
+  Optional<Artwork> findMainArtworkByExhibitId(@Param("exhibit") Exhibit exhibit);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ArtworkRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ArtworkRepository.java
@@ -3,6 +3,8 @@ package com.yapp.artie.domain.archive.repository;
 import com.yapp.artie.domain.archive.domain.artwork.Artwork;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +19,11 @@ public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
       "select e from Artwork e where e.exhibit = :exhibit and e.isMain = true "
   )
   Optional<Artwork> findMainArtworkByExhibitId(@Param("exhibit") Exhibit exhibit);
+
+  @Query(
+      value = "select a from Artwork a "
+          + "where a.exhibit = :exhibit ",
+      countQuery = "select count(a.id) from Artwork a"
+  )
+  Page<Artwork> findAllArtworkAsPage(Pageable pageable, @Param("exhibit") Exhibit exhibit);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -20,6 +20,9 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   @EntityGraph(attributePaths = {"user"})
   Optional<Exhibit> findExhibitEntityGraphById(Long id);
 
+  @EntityGraph(attributePaths = {"user", "category"})
+  Optional<Exhibit> findDetailExhibitEntityGraphById(Long id);
+
   @Query("select new com.yapp.artie.domain.archive.dto.exhibit."
       + "PostInfoDto(e.id, e.contents.name, e.contents.date, e.publication.isPublished) "
       + "from Exhibit e where e.user = :user and e.publication.isPublished = false")

--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -2,6 +2,7 @@ package com.yapp.artie.domain.archive.service;
 
 import com.yapp.artie.domain.archive.domain.artwork.Artwork;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.dto.artwork.ArtworkThumbnailDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkRequestDto;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfExhibitException;
 import com.yapp.artie.domain.archive.repository.ArtworkRepository;
@@ -10,6 +11,8 @@ import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +25,8 @@ public class ArtworkService {
   private final ExhibitRepository exhibitRepository;
   private final ArtworkRepository artworkRepository;
   private final TagService tagService;
+  private final ExhibitService exhibitService;
+  ;
 
   @Transactional
   public Long create(CreateArtworkRequestDto createArtworkRequestDto, Long userId) {
@@ -42,5 +47,21 @@ public class ArtworkService {
     tagService.addTagsToArtwork(createArtworkRequestDto.getTags(), artwork, user);
 
     return artwork.getId();
+  }
+
+  public Page<ArtworkThumbnailDto> getArtworkAsPage(Long exhibitId, Long userId,
+      Pageable pageable) {
+    Exhibit exhibit = exhibitService.getExhibitByUser(exhibitId, userId);
+    return artworkRepository.findAllArtworkAsPage(pageable, exhibit)
+        .map(this::buildArtworkThumbnail);
+  }
+
+  private ArtworkThumbnailDto buildArtworkThumbnail(Artwork artwork) {
+    return ArtworkThumbnailDto.builder()
+        .id(artwork.getId())
+        .imageURL(artwork.getContents().getUri())
+        .name(artwork.getContents().getName())
+        .artist(artwork.getContents().getArtist())
+        .build();
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -90,6 +90,13 @@ public class ExhibitService {
     exhibit.update(updateExhibitRequestDto.getName(), updateExhibitRequestDto.getPostDate());
   }
 
+  public Exhibit getExhibitByUser(Long id, Long userId) {
+    Exhibit exhibit = exhibitRepository.findExhibitEntityGraphById(id)
+        .orElseThrow(ExhibitNotFoundException::new);
+    validateOwnedByUser(findUser(userId), exhibit);
+    return exhibit;
+  }
+
   private User findUser(Long userId) {
     return userService.findById(userId);
   }

--- a/src/main/java/com/yapp/artie/domain/s3/controller/S3Controller.java
+++ b/src/main/java/com/yapp/artie/domain/s3/controller/S3Controller.java
@@ -7,6 +7,8 @@ import com.yapp.artie.domain.s3.service.S3Service;
 import com.yapp.artie.domain.user.service.UserService;
 import com.yapp.artie.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -57,7 +59,7 @@ public class S3Controller {
   public ResponseEntity<GetPresignedUrlResponseDto> generateArtworkPresignedUrl(
       Authentication authentication,
       @RequestBody @Valid GetPresignedUrlRequestDto getPresignedUrlRequestDto,
-      @RequestParam(required = true, value = "id") Long postId) {
+      @Parameter(name = "id", description = "전시 ID", in = ParameterIn.QUERY) @Valid @RequestParam(required = true, value = "id") Long postId) {
     Long userId = Long.parseLong(authentication.getName());
     userService.findById(userId);
 
@@ -66,7 +68,7 @@ public class S3Controller {
         .stream().map(imageName -> s3Service.getPresignedUrl(imageName, postId,
             index.getAndIncrement())).filter(url -> url.isPresent()).filter(Optional::isPresent)
         .map(Optional::get).collect(Collectors.toList());
-    
+
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(new GetPresignedUrlResponseDto(urlDataList));
   }

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -9,3 +9,5 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+    cloudfront:
+      domain: ${AWS_CDN_DOMAIN}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- S3 Presigned URL 발급 API의 Path Parameter가 post ID임을 안내하도록 Swagger 수정
- S3 Presigned URL 발급 API의 Path Parameter에 대한 Validation 추가
- 작품 등록 API의 imageUri property가 S3 Presigned URL발급 후 반환되는 imageKey와 일치해야함을 안내하도록 Swagger 수정 
- 작품 등록 API의 tags property에 대해, 태그 ID 필드는 기존에 존재하는 태그를 등록할 경우에는 필수로 제공되어야함을 안내하도록 Swagger 수정
- 전시 상세 정보 API 추가
- 작품 목록 조회 API 추가



## 관련 이슈

close #32 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




