### PR TITLE
작품 수정, 다중 작품 등록 API 개발 및 일부 Swagger 값 수정

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/controller/ArtworkController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ArtworkController.java
@@ -8,6 +8,7 @@ import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkBatchRequestDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkBatchResponseDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkRequestDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkResponseDto;
+import com.yapp.artie.domain.archive.dto.artwork.UpdateArtworkRequestDto;
 import com.yapp.artie.domain.archive.service.ArtworkService;
 import com.yapp.artie.global.exception.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +32,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -270,5 +272,47 @@ public class ArtworkController {
         .body(new CreateArtworkBatchResponseDto(
             artworkService.createBatch(createArtworkBatchRequestDtoRequestDto.getImageUriList(),
                 exhibitId, userId)));
+  }
+
+  @Operation(summary = "작품 정보 수정", description = "작품의 작가정보, 작품명, 태그 정보 수정")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204",
+          description = "전시 작품이 성공적으로 추가됨",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 입력",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증 오류",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 회원",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 전시",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 태그. 요청한 태그 ID에 해당 하는 태그를 찾을 수 없습니다.",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "409",
+          description = "이미 존재하는 태그. 이미 존재하는 태그를 등록하는 경우는 태그 ID를 함께 요청해야합니다.",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+  })
+  @PatchMapping("/{id}")
+  public ResponseEntity<? extends HttpEntity> createArtwork(Authentication authentication,
+      @Parameter(name = "id", description = "작품 ID", in = ParameterIn.PATH) @Valid @PathVariable("id") Long artworkId,
+      @RequestBody @Valid
+      UpdateArtworkRequestDto updateArtworkRequestDto) {
+
+    Long userId = Long.parseLong(authentication.getName());
+    artworkService.update(artworkId, userId, updateArtworkRequestDto);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ArtworkController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ArtworkController.java
@@ -4,6 +4,8 @@ import com.yapp.artie.domain.archive.dto.artwork.ArtworkBrowseThumbnailDto;
 import com.yapp.artie.domain.archive.dto.artwork.ArtworkInfoDto;
 import com.yapp.artie.domain.archive.dto.artwork.ArtworkThumbnailDto;
 import com.yapp.artie.domain.archive.dto.artwork.ArtworkThumbnailDtoPage;
+import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkBatchRequestDto;
+import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkBatchResponseDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkRequestDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkResponseDto;
 import com.yapp.artie.domain.archive.service.ArtworkService;
@@ -224,5 +226,49 @@ public class ArtworkController {
     Long userId = Long.parseLong(authentication.getName());
     artworkService.delete(id, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "전시 작품 다중 추가", description = "다중 작품(이미지)를 전시에 추가")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "201",
+          description = "전시 작품이 성공적으로 추가됨",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = CreateArtworkBatchResponseDto.class))),
+      @ApiResponse(
+          responseCode = "400",
+          description = "잘못된 입력",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증 오류",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "403",
+          description = "접근 불가능한 전시",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 회원",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "찾을 수 없는 태그",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(
+          responseCode = "409",
+          description = "이미 존재하는 태그",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+  })
+  @PostMapping("batch/{id}")
+  public ResponseEntity<CreateArtworkBatchResponseDto> createArtwork(Authentication authentication,
+      @Parameter(name = "id", description = "전시 ID", in = ParameterIn.PATH) @Valid @PathVariable("id") Long exhibitId,
+      @RequestBody @Valid CreateArtworkBatchRequestDto createArtworkBatchRequestDtoRequestDto) {
+
+    Long userId = Long.parseLong(authentication.getName());
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(new CreateArtworkBatchResponseDto(
+            artworkService.createBatch(createArtworkBatchRequestDtoRequestDto.getImageUriList(),
+                exhibitId, userId)));
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
@@ -53,4 +53,9 @@ public class Artwork extends BaseEntity {
     ArtworkContents contents = new ArtworkContents.Builder(uri).name(name).artist(artist).build();
     return new Artwork(exhibit, isMain, contents);
   }
+
+  public static Artwork create(Exhibit exhibit, boolean isMain, String uri) {
+    ArtworkContents contents = new ArtworkContents.Builder(uri).build();
+    return new Artwork(exhibit, isMain, contents);
+  }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/ArtworkContents.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/ArtworkContents.java
@@ -56,4 +56,12 @@ public class ArtworkContents {
       return new ArtworkContents(this);
     }
   }
+
+  public void updateArtist(String artist) {
+    this.artist = artist;
+  }
+
+  public void updateName(String name) {
+    this.name = name;
+  }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkBatchRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkBatchRequestDto.java
@@ -1,0 +1,19 @@
+package com.yapp.artie.domain.archive.dto.artwork;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "전시 작품 다중 생성 Request")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateArtworkBatchRequestDto {
+
+  @Valid
+  @Schema(description = "s3 이미지 URI 목록. S3 Presigned URL 발급 후 반환한 imageKey 값 목록")
+  private List<@NotBlank String> imageUriList;
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkBatchResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkBatchResponseDto.java
@@ -1,0 +1,16 @@
+package com.yapp.artie.domain.archive.dto.artwork;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "전시 작품 다중 생성 Response")
+@RequiredArgsConstructor
+public class CreateArtworkBatchResponseDto {
+
+  @Schema(description = "전시 작품 아이디 목록")
+  private final List<Long> idList;
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkRequestDto.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Schema(description = "전시 생성 Request")
+@Schema(description = "전시 작품 생성 Request")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateArtworkRequestDto {
 

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/UpdateArtworkRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/UpdateArtworkRequestDto.java
@@ -1,0 +1,33 @@
+package com.yapp.artie.domain.archive.dto.artwork;
+
+import com.yapp.artie.domain.archive.dto.tag.CreateArtworkTagDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "전시 작품 생성 Request")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateArtworkRequestDto {
+
+  @Schema(description = "작가 이름")
+  private String artist;
+
+  @Schema(description = "작품명")
+  private String name;
+
+  @Valid
+  @Schema(description = "작품 할당 태그")
+  private List<CreateArtworkTagDto> tags;
+
+  @Builder
+  public UpdateArtworkRequestDto(String artist, String name, List<CreateArtworkTagDto> tags) {
+    this.artist = artist;
+    this.name = name;
+    this.tags = tags;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -6,6 +6,7 @@ import com.yapp.artie.domain.archive.dto.artwork.ArtworkBrowseThumbnailDto;
 import com.yapp.artie.domain.archive.dto.artwork.ArtworkInfoDto;
 import com.yapp.artie.domain.archive.dto.artwork.ArtworkThumbnailDto;
 import com.yapp.artie.domain.archive.dto.artwork.CreateArtworkRequestDto;
+import com.yapp.artie.domain.archive.dto.artwork.UpdateArtworkRequestDto;
 import com.yapp.artie.domain.archive.dto.tag.TagDto;
 import com.yapp.artie.domain.archive.exception.ArtworkNotFoundException;
 import com.yapp.artie.domain.archive.repository.ArtworkRepository;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -95,6 +97,22 @@ public class ArtworkService {
     String imageUri = artwork.getContents().getUri();
     artworkRepository.delete(artwork);
     s3Service.deleteObject(imageUri);
+  }
+
+  @Transactional
+  public void update(Long artworkId, Long userId, UpdateArtworkRequestDto updateArtworkRequestDto) {
+    Artwork artwork = findById(artworkId, userId);
+    if (StringUtils.isNotBlank(updateArtworkRequestDto.getArtist())) {
+      artwork.getContents().updateArtist(updateArtworkRequestDto.getArtist());
+    }
+    if (StringUtils.isNotBlank(updateArtworkRequestDto.getName())) {
+      artwork.getContents().updateName(updateArtworkRequestDto.getName());
+    }
+    if (updateArtworkRequestDto.getTags() != null) {
+      artworkTagService.deleteAllByArtwork(artwork);
+      tagService.addTagsToArtwork(updateArtworkRequestDto.getTags(), artwork,
+          userService.findById(userId));
+    }
   }
 
   private ArtworkThumbnailDto buildArtworkThumbnail(Artwork artwork) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/TagService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/TagService.java
@@ -52,7 +52,6 @@ public class TagService {
     return tag;
   }
 
-
   private void validateDuplicateTagName(String tagName, User user) {
     List<TagDto> tags = tagRepository.findTagDto(user);
     long count = tags.stream().filter(tagDto -> tagDto.getName().equals(tagName)).count();


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 작품 수정 API 개발
- 다중 작품 등록 API 개발 : 이미지 Key 리스트를 요청받아 각각의 작품으로 생성하는 API
- 전시 작품 생성 API Swagger API Response의 설명 수정

## 관련 이슈

close #40 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




