### PR TITLE
캘린더 월별 작품 조회 기능 구현

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -1,6 +1,8 @@
 package com.yapp.artie.domain.archive.controller;
 
 
+import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
+import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/post")
@@ -55,6 +58,27 @@ public class ExhibitController {
     PostInfoDto exhibitInformation = exhibitService.getExhibitInformation(id, userId);
 
     return ResponseEntity.ok().body(exhibitInformation);
+  }
+
+  @Operation(summary = "월별 전시 조회", description = "월별로 전시 목록 조회")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "월별 전시가 성공적으로 조회됨",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = CalendarExhibitResponseDto.class))),
+  })
+  @GetMapping("/monthly")
+  public ResponseEntity<List<CalendarExhibitResponseDto>> getPostByMonthly(
+      Authentication authentication,
+      @Parameter(example = "2023", description = "yyyy")
+      @RequestParam("year") int year,
+      @Parameter(example = "02", description = "mm")
+      @RequestParam("month") int month) {
+    Long userId = Long.parseLong(authentication.getName());
+
+    return ResponseEntity.ok()
+        .body(
+            exhibitService.getExhibitByMonthly(new CalendarExhibitRequestDto(year, month), userId));
   }
 
   @Operation(summary = "임시 저장 전시 조회", description = "임시 저장된 전시 목록 조회")
@@ -104,8 +128,7 @@ public class ExhibitController {
   })
   @PostMapping()
   public ResponseEntity<CreateExhibitResponseDto> createPost(Authentication authentication,
-      @RequestBody
-      CreateExhibitRequestDto createExhibitRequestDto) {
+      @RequestBody CreateExhibitRequestDto createExhibitRequestDto) {
     Long userId = Long.parseLong(authentication.getName());
     Long id = exhibitService.create(createExhibitRequestDto, userId);
 

--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/ArtworkContents.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/ArtworkContents.java
@@ -1,5 +1,6 @@
 package com.yapp.artie.domain.archive.domain.artwork;
 
+import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -55,6 +56,13 @@ public class ArtworkContents {
     public ArtworkContents build() {
       return new ArtworkContents(this);
     }
+  }
+
+  public String getFullUri(String cdnDomain) {
+    if (Optional.ofNullable(uri).isEmpty()) {
+      return null;
+    }
+    return cdnDomain + uri;
   }
 
   public void updateArtist(String artist) {

--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/NullArtwork.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/NullArtwork.java
@@ -1,0 +1,23 @@
+package com.yapp.artie.domain.archive.domain.artwork;
+
+// TODO : null object, 현재 구현 상속(extends)한 상황, 타입 상속(implements)으로 변경 필요
+// [null object pattern(special case)](https://martinfowler.com/eaaCatalog/specialCase.html)
+public class NullArtwork extends Artwork {
+
+  private NullArtwork() {
+    super(null, false, new ArtworkContents
+        .Builder(null)
+        .name(null)
+        .artist(null)
+        .build());
+  }
+
+  @Override
+  public Long getId() {
+    return 0L;
+  }
+
+  public static Artwork create() {
+    return new NullArtwork();
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitRequestDto.java
@@ -9,10 +9,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CalendarExhibitRequestDto {
 
-  @Schema(description = "연도(year)")
+  @Schema(description = "연도(year)", example = "2023")
   private final int year;
 
-  @Schema(description = "월(month)")
+  @Schema(description = "월(month)", example = "1")
   private final int month;
 }
 

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitRequestDto.java
@@ -1,0 +1,18 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "월별 전시 조회 Request")
+@RequiredArgsConstructor
+public class CalendarExhibitRequestDto {
+
+  @Schema(description = "연도(year)")
+  private final int year;
+
+  @Schema(description = "월(month)")
+  private final int month;
+}
+

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
@@ -19,5 +19,5 @@ public class CalendarExhibitResponseDto {
   private final int day;
 
   @Schema(description = "작품 이미지")
-  private String imageURL;
+  private final String imageURL;
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
@@ -1,0 +1,23 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "월별 전시 조회 Response")
+@RequiredArgsConstructor
+public class CalendarExhibitResponseDto {
+
+  @Schema(description = "연도(year)")
+  private final int year;
+
+  @Schema(description = "월(month)")
+  private final int month;
+
+  @Schema(description = "일(day)")
+  private final int day;
+
+  @Schema(description = "작품 이미지")
+  private String imageURL;
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
@@ -18,6 +18,9 @@ public class CalendarExhibitResponseDto {
   @Schema(description = "일(day)")
   private final int day;
 
-  @Schema(description = "작품 이미지")
+  @Schema(description = "대표 이미지")
   private final String imageURL;
+
+  @Schema(description = "임시 저장 여부")
+  private final boolean isPublished;
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -39,6 +39,12 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   Page<Exhibit> findExhibitAllCountBy(Pageable pageable, @Param("user") User user,
       @Param("category") Category category);
 
-  List<Exhibit> findAllByContentsDateBetweenAndUser(LocalDate start, LocalDate end,
-      User user);
+  @Query("select e from Exhibit e "
+      + "where e.user = :user "
+      + "and e.contents.date between :start and :end "
+      + "order by e.contents.date asc, e.createdAt asc"
+  )
+  List<Exhibit> findAllExhibitForCalendar(@Param("start") LocalDate start,
+      @Param("end") LocalDate end,
+      @Param("user") User user);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -4,6 +4,7 @@ import com.yapp.artie.domain.archive.domain.category.Category;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.user.domain.User;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -28,7 +29,6 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
       + "from Exhibit e where e.user = :user and e.publication.isPublished = false")
   List<PostInfoDto> findDraftExhibitDto(@Param("user") User user);
 
-
   @Query(
       value = "select e from Exhibit e "
           + "where e.user = :user "
@@ -38,4 +38,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   )
   Page<Exhibit> findExhibitAllCountBy(Pageable pageable, @Param("user") User user,
       @Param("category") Category category);
+
+  List<Exhibit> findAllByContentsDateBetweenAndUser(LocalDate start, LocalDate end,
+      User user);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -118,7 +118,7 @@ public class ArtworkService {
   private ArtworkThumbnailDto buildArtworkThumbnail(Artwork artwork) {
     return ArtworkThumbnailDto.builder()
         .id(artwork.getId())
-        .imageURL(cdnDomain + artwork.getContents().getUri())
+        .imageURL(artwork.getContents().getFullUri(cdnDomain))
         .name(artwork.getContents().getName())
         .artist(artwork.getContents().getArtist())
         .build();
@@ -127,7 +127,7 @@ public class ArtworkService {
   private ArtworkInfoDto buildArtworkInfo(Artwork artwork, List<TagDto> tags) {
     return ArtworkInfoDto.builder()
         .id(artwork.getId())
-        .imageURL(cdnDomain + artwork.getContents().getUri())
+        .imageURL(artwork.getContents().getFullUri(cdnDomain))
         .name(artwork.getContents().getName())
         .artist(artwork.getContents().getArtist())
         .tags(tags)
@@ -136,7 +136,7 @@ public class ArtworkService {
 
   private ArtworkBrowseThumbnailDto buildArtworkBrowseThumbnail(Artwork artwork) {
     return new ArtworkBrowseThumbnailDto(artwork.getId(),
-        cdnDomain + artwork.getContents().getUri());
+        artwork.getContents().getFullUri(cdnDomain));
   }
 
   private Artwork findById(Long id, Long userId) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -2,6 +2,7 @@ package com.yapp.artie.domain.archive.service;
 
 import com.yapp.artie.domain.archive.domain.category.Category;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
@@ -12,6 +13,10 @@ import com.yapp.artie.domain.archive.repository.ArtworkRepository;
 import com.yapp.artie.domain.archive.repository.ExhibitRepository;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.service.UserService;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,6 +64,18 @@ public class ExhibitService {
     Category category = categoryService.findCategoryWithUser(id, userId);
     return exhibitRepository.findExhibitAllCountBy(pageable, findUser(userId), category)
         .map(this::buildExhibitionInformation);
+  }
+
+  public List<Exhibit> getExhibitByMonthly(
+      CalendarExhibitRequestDto calendarExhibitRequestDto, Long userId) throws ParseException {
+    User user = findUser(userId);
+    int year = calendarExhibitRequestDto.getYear();
+    Month month = Month.of(calendarExhibitRequestDto.getMonth());
+    YearMonth yearMonth = YearMonth.of(year, month);
+    LocalDate start = yearMonth.atDay(1);
+    LocalDate end = yearMonth.atEndOfMonth();
+
+    return exhibitRepository.findAllByContentsDateBetweenAndUser(start, end, user);
   }
 
   @Transactional

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -53,7 +53,7 @@ public class ExhibitService {
     validateOwnedByUser(findUser(userId), exhibit);
 
     String mainImageUri = artworkRepository.findMainArtworkByExhibitId(exhibit)
-        .map(artwork -> cdnDomain + artwork.getContents().getUri()).orElse(null);
+        .map(artwork -> artwork.getContents().getFullUri(cdnDomain)).orElse(null);
     return buildDetailExhibitionInformation(exhibit, mainImageUri);
   }
 
@@ -61,6 +61,7 @@ public class ExhibitService {
     return exhibitRepository.findDraftExhibitDto(findUser(userId));
   }
 
+  // TODO : buildDetailExhibitionInformation 사용하도록 변경 필요
   public Page<PostInfoDto> getExhibitByPage(Long id, Long userId, Pageable pageable) {
     Category category = categoryService.findCategoryWithUser(id, userId);
     return exhibitRepository.findExhibitAllCountBy(pageable, findUser(userId), category)
@@ -83,7 +84,7 @@ public class ExhibitService {
           exhibit.contents().getDate().getYear(),
           exhibit.contents().getDate().getMonthValue(),
           exhibit.contents().getDate().getDayOfMonth(),
-          mainArtwork.getContents().getUri());
+          mainArtwork.getContents().getFullUri(cdnDomain));
     }).collect(Collectors.toList());
   }
 

--- a/src/main/java/com/yapp/artie/global/util/DateUtils.java
+++ b/src/main/java/com/yapp/artie/global/util/DateUtils.java
@@ -1,0 +1,20 @@
+package com.yapp.artie.global.util;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.YearMonth;
+
+public class DateUtils {
+
+  public static LocalDate getFirstDayOf(int year, int month) {
+    return YearMonth.of(year, monthOf(month)).atDay(1);
+  }
+
+  public static LocalDate getLastDayOf(int year, int month) {
+    return YearMonth.of(year, monthOf(month)).atEndOfMonth();
+  }
+
+  private static Month monthOf(int month) {
+    return Month.of(month);
+  }
+}

--- a/src/test/java/com/yapp/artie/DateUtilTest.java
+++ b/src/test/java/com/yapp/artie/DateUtilTest.java
@@ -1,0 +1,33 @@
+package com.yapp.artie;
+
+import com.yapp.artie.global.util.DateUtils;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.HashSet;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DateUtilTest {
+
+  @Test
+  public void test_local_date_동등성_비교() throws Exception {
+    //given
+    HashMap<LocalDate, Integer> hash = new HashMap<>();
+    HashSet<LocalDate> set = new HashSet<>();
+
+    LocalDate test1 = DateUtils.getFirstDayOf(2023, 12);
+    LocalDate test2 = DateUtils.getFirstDayOf(2023, 12);
+
+    //when
+    hash.put(test1, 1);
+    hash.put(test2, 1);
+    set.add(test1);
+    set.add(test2);
+
+    //then
+    Assertions.assertThat(hash.size()).isEqualTo(1);
+    Assertions.assertThat(test1.equals(test2)).isTrue();
+    Assertions.assertThat(test1 == test2).isFalse();
+    Assertions.assertThat(set.size()).isEqualTo(1);
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.dto.cateogry.CategoryDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
+import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
@@ -148,7 +149,8 @@ class ExhibitServiceTest {
 
     for (int i = 1; i <= 12; i++) {
       CalendarExhibitRequestDto calendarExhibitRequestDto = new CalendarExhibitRequestDto(2023, i);
-      List<Exhibit> exhibitByMonthly = exhibitService.getExhibitByMonthly(calendarExhibitRequestDto,
+      List<CalendarExhibitResponseDto> exhibitByMonthly = exhibitService.getExhibitByMonthly(
+          calendarExhibitRequestDto,
           user.getId());
 
       assertThat(exhibitByMonthly.size()).isEqualTo(1);

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.dto.cateogry.CategoryDto;
+import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
@@ -13,6 +14,8 @@ import com.yapp.artie.domain.archive.exception.NotOwnerOfCategoryException;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -129,6 +132,27 @@ class ExhibitServiceTest {
     PostInfoDto actual = exhibitService.getExhibitInformation(exhibit.getId(),
         user.getId());
     assertThat(actual.getName()).isEqualTo(updatedName);
+  }
+
+  @Test
+  public void getExhibitByMonthly_월_별로_전시를_조회한다() throws Exception {
+    User user = createUser("user", "tu");
+    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+
+    for (int i = 1; i <= 12; i++) {
+      CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
+          defaultCateogry.getId(),
+          LocalDate.of(2023, Month.of(i), 1));
+      exhibitService.create(exhibitRequestDto, user.getId());
+    }
+
+    for (int i = 1; i <= 12; i++) {
+      CalendarExhibitRequestDto calendarExhibitRequestDto = new CalendarExhibitRequestDto(2023, i);
+      List<Exhibit> exhibitByMonthly = exhibitService.getExhibitByMonthly(calendarExhibitRequestDto,
+          user.getId());
+
+      assertThat(exhibitByMonthly.size()).isEqualTo(1);
+    }
   }
 }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약
캘린더 페이지에서 월 단위로 전시를 조회하는 기능을 구현했습니다. 아래 데이터 구조의 배열 형태로 응답합니다.

```json
{
    "year" : 2023,
    "month" : 2,
    "day" : 1,
    "imageUri" : "....",
    "isPublished" : true
}
```

## 관련 이슈

close #37 

## 구현 내용

- [x] 캘린더 조회 기능 구현
- [x] 날짜와 관련된 유틸성 클래스 구현


