### PR TITLE
Swagger에서 Page객체에 담겨 반환됨을 정상적으로 명시

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/controller/ArtworkController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ArtworkController.java
@@ -95,7 +95,7 @@ public class ArtworkController {
       @ApiResponse(
           responseCode = "200",
           description = "전시 작품 목록 조회",
-          content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ArtworkThumbnailDtoPage.class)))),
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ArtworkThumbnailDtoPage.class))),
       @ApiResponse(
           responseCode = "400",
           description = "잘못된 입력",

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -6,6 +6,7 @@ import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
+import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfoPage;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.service.ExhibitService;
@@ -104,7 +105,7 @@ public class ExhibitController {
       @ApiResponse(
           responseCode = "200",
           description = "홈 화면 전시 목록(특정 카테고리)이 성공적으로 조회됨",
-          content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PostDetailInfo.class)))),
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostDetailInfoPage.class))),
   })
   @GetMapping("/home/{id}")
   public ResponseEntity<Page<PostDetailInfo>> getPostPage(
@@ -128,7 +129,7 @@ public class ExhibitController {
       @ApiResponse(
           responseCode = "200",
           description = "홈 화면 전시 목록(전체 기록)이 성공적으로 조회됨",
-          content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PostDetailInfo.class)))),
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostDetailInfoPage.class))),
   })
   @GetMapping("/home")
   public ResponseEntity<Page<PostDetailInfo>> getAllPostPage(

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfoPage.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfoPage.java
@@ -1,0 +1,13 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import java.util.List;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class PostDetailInfoPage extends PageImpl<PostDetailInfo> {
+
+  public PostDetailInfoPage(List<PostDetailInfo> content,
+      Pageable pageable, long total) {
+    super(content, pageable, total);
+  }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- Page 객체에 담기지만 contents의 타입만 보이는 현상의 개선
- Page 객체에 contents의 타입이 잘 명세되어 보여지나, Page객체 자체까지 배열 타입으로 보이는 현상의 개선

## 관련 이슈

close #65 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




