### PR TITLE
카테고리 순서 변경 테스트

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
@@ -26,6 +26,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   int countCategoriesByUser(@Param("user") User user);
 
-  List<Category> findCategoriesByUser(User user);
+  List<Category> findCategoriesByUserOrderBySequence(User user);
 }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
@@ -75,7 +75,7 @@ public class CategoryService {
   @Transactional
   public void shuffle(List<CategoryDto> changeCategorySequenceDtos, Long userId) {
     User user = findUser(userId);
-    List<Category> categories = categoryRepository.findCategoriesByUser(user);
+    List<Category> categories = categoryRepository.findCategoriesByUserOrderBySequence(user);
     validateChangeCategoriesLengthWithOriginal(changeCategorySequenceDtos, categories);
 
     int sequence = 1;

--- a/src/test/java/com/yapp/artie/domain/archive/service/CategoryServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/CategoryServiceTest.java
@@ -197,7 +197,7 @@ class CategoryServiceTest {
 
   @ParameterizedTest(name = "[카테고리 순서 변경 테스트 #{index}] => {0}순으로 재배열하는 경우")
   @ValueSource(strings = {"12345", "12435", "14523", "43215", "52134", "25431", "12354", "12534",
-      "43521", "32145", "32514"})
+      "43521", "32145", "32514", "1234", "4321", "321", "231", "132", "21", "12", "1"})
   public void shuffle_카테고리의_순서를_변경한다(String expected) throws Exception {
     //given
     List<Integer> expectedList = Arrays.stream(expected.split(""))
@@ -205,7 +205,7 @@ class CategoryServiceTest {
         .boxed()
         .collect(Collectors.toList());
     User user = findUser("1");
-    createCategoryBy(user, 5);
+    createCategoryBy(user, expected.length());
 
     //when
     List<CategoryDto> shuffled = new ArrayList<>();


### PR DESCRIPTION
# 구현 내용

## 구현 요약

카테고리 순서 변경 로직이  카테고리 조회 쿼리에 order by에 의존적이도록 구현되어 있는데, 정작 order by가 존재하지 않아서 첫 테스트는 통과하고(처음에는 시퀀스가 정렬), 이후에는 변경이 안되는 버그를 수정 + 테스트 케이스 추가 

## 관련 이슈

close #59 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




