### PR TITLE
전시 상단 고정 기능 추가, 카테고리별 전시 목록 조회 API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 5. 실행
 
-데이터베이스 실행 :
+### 5.1 데이터베이스 실행 :
 
 ```shell
 # mysql 실행
@@ -61,23 +61,34 @@ $ cd docker
 $ docker-compose down
 ```
 
-profile 환경변수 설정 :
+### 5.2 profile 환경변수 설정 :
 
 1. 인텔리제이 메뉴 Run > Edit Configurations 설정 접속 혹은 스크린 샷과 같이 접속
    <img width="863" alt="스크린샷 2023-01-07 오후 4 06 05" src="https://user-images.githubusercontent.com/42285463/211137975-87d0e79c-7f8b-4640-9eae-0ad03d68fef5.png">
 2. Active profiles에 develop 입력 ( 개발용의 경우 develop, production의 경우 prod 입력 )
    <img width="1042" alt="스크린샷 2023-01-07 오후 4 07 21" src="https://user-images.githubusercontent.com/42285463/211138359-e071c6ff-6fa5-432e-87e0-101e759b6037.png">
 
-환경 변수 추가 및 변경 시 ( production ) :
+### 5.3 환경 변수 추가 및 변경 시 ( production ) :
 
 - application-dev.yml에 해당하는 환경변수를 추가하고, 환경변수 구조 파악을 위하여 application-prod.yml에 추가되는 환경변수의 이름을 추가.
 - 실제 환경변수 값이 포함된 application-prod.yml을 base 64로 인코딩하여 Github Secrets에 업데이트
 
-인텔리제이에 환경변수 추가 :
+### 5.4 인텔리제이에 환경변수 추가 :
 
 1. 인텔리제이 메뉴 Run > Edit Configurations 설정 접속 ( profile 환경변수 설정 섹션 참고 )
 2. Modify Options > Environment Variables 체크
 3. 해당하는 환경변수 추가
+
+### 5.5 테스트 시 환경변수를 템플릿으로 설정 :
+
+테스트를 수행할 때마다, 환경변수를 설정하는 작업을, 인텔리제이에서 템플릿으로 설정하면 테스트마다 설정하지 않아도 됩니다.
+
+1. 인텔리제이 메뉴 Run > Edit Configurations 설정 접속 혹은 스크린 샷과 같이 접속
+   <img width="863" alt="스크린샷 2023-01-07 오후 4 06 05" src="https://user-images.githubusercontent.com/42285463/211137975-87d0e79c-7f8b-4640-9eae-0ad03d68fef5.png">
+2. 좌측 하단 Edit configuration templates 클릭
+   ![스크린샷 2023-02-08 오후 4 34 00](https://user-images.githubusercontent.com/42285463/217463831-b6ff6405-ffd6-4783-83c4-30db0bdfa8f0.png)
+3. JUnit을 선택한 후, 테스트 실행시와 동일한 설정값을 입력하고, 환경변수 입력한다. 그리고 테스트 설정을 설정할 범위를 'All in directory'에 명세한다.
+   ![스크린샷 2023-02-08 오후 4 34 47](https://user-images.githubusercontent.com/42285463/217464007-55927e00-94db-41bb-b1f7-56de17f3358e.png)
 
 ## 6. 배포
 

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -32,6 +32,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -247,6 +248,30 @@ public class ExhibitController {
       @Parameter(name = "id", description = "전시 ID", in = ParameterIn.PATH) @Valid @PathVariable("id") Long id) {
     Long userId = getUserId(authentication);
     return ResponseEntity.ok().body(exhibitService.getDetailExhibitInformation(id, userId));
+  }
+
+  @Operation(summary = "전시 상단 고정 설정", description = "특정 전시를 홈페이지에서 전체 기록 혹은 특정 카테고리에 대해 상단에 고정되어 조회할 수 있도록 설정")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204",
+          description = "성공적으로 상단 고정 설정됨",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))),
+  })
+  @PatchMapping("/pin")
+  public ResponseEntity<? extends HttpEntity> updatePostPinType(
+      Authentication authentication,
+      @Parameter(name = "id", description = "전시 ID", in = ParameterIn.QUERY)
+      @RequestParam(value = "id", required = true) Long exhibitId,
+      @Parameter(name = "category", description = "카테고리에 고정하는지의 여부. "
+          + "true일 경우, 해당 전시의 카테고리 상단 고정으로, false일 경우 전체 기록의 상단 고정 설정으로 처리",
+          in = ParameterIn.QUERY)
+      @RequestParam(value = "category", required = true, defaultValue = "true") boolean categoryType,
+      @Parameter(name = "pinned", description = "고정 여부. 고정하도록 설정한다면 true, 고정 해제하도록 설정한다면 false", in = ParameterIn.QUERY)
+      @RequestParam(value = "pinned", required = true, defaultValue = "true") boolean pinned
+  ) {
+    Long userId = getUserId(authentication);
+    exhibitService.updatePostPinType(userId, exhibitId, categoryType, pinned);
+    return ResponseEntity.noContent().build();
   }
 
   // TODO : 앱 배포했을 때에는 1L 대신에 exception을 던지도록 변경해야 합니다.

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -100,9 +100,7 @@ public class ExhibitController {
   }
 
   @Operation(summary = "홈 화면 전시 조회(특정 카테고리)", description =
-      "저장된 전시 중 페이지네이션을 이용해 값을 가져온다. 이곳의 id는 category id를 의미하며 "
-          + "size의 기본값은 20이다. sort는 기본값이 최신 순이고, ?sort=contents.date,ASC 는 오래된 순이다. "
-          + "오래된 순의 예시처럼 콤마를 기준으로 [<정렬 컬럼>,<정렬 타입 형식>]으로 쿼리 파라미터를 전달해야 한다."
+      "해당 API는 [GET] /post/home API와 통합되어, deprecated될 예정입니다. "
   )
   @ApiResponses(value = {
       @ApiResponse(
@@ -128,11 +126,11 @@ public class ExhibitController {
     return ResponseEntity.ok().body(pageResult);
   }
 
-  @Operation(summary = "홈 화면 전시 조회(전체 기록)", description = "용례는 홈 화면 전시 조회(특정 카테고리)와 같다.")
+  @Operation(summary = "홈 화면 전시 조회(전체 기록/특정 카테고리)", description = "홈 화면의 전체 기록 혹은 특정 카테고리 별, 상단 고정 설정을 반영한 전시 목록 조회")
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "200",
-          description = "홈 화면 전시 목록(전체 기록)이 성공적으로 조회됨",
+          description = "홈 화면 전시 목록이 성공적으로 조회됨",
           content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostDetailInfoPage.class))),
   })
   @GetMapping("/home")
@@ -143,10 +141,14 @@ public class ExhibitController {
       @Parameter(name = "page", description = "페이지네이션의 페이지 넘버. 0부터 시작함", in = ParameterIn.QUERY)
       @RequestParam(value = "page", required = false, defaultValue = "0") int page,
       @Parameter(name = "direction", description = "페이지네이션의 정렬기준. DESC=최신순, ASC=오래된순", in = ParameterIn.QUERY)
-      @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction) {
+      @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction,
+      @Parameter(name = "category", description = "카테고리 ID. 홈 화면의 카테고리별 전시 목록 조회시 해당 파라미터를 입력해야함.", in = ParameterIn.QUERY)
+      @RequestParam(name = "category", required = false) Long categoryId
+  ) {
 
     Long userId = getUserId(authentication);
-    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(null, userId, page, size,
+    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(categoryId, userId, page,
+        size,
         direction);
 
     return ResponseEntity.ok().body(pageResult);

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -7,6 +7,8 @@ import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfoPage;
+import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDto;
+import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDtoPage;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.service.ExhibitService;
@@ -273,6 +275,26 @@ public class ExhibitController {
     Long userId = getUserId(authentication);
     exhibitService.updatePostPinType(userId, exhibitId, categoryType, pinned);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "카테고리별 전시 목록 조회(카테고리 페이지)", description = "카테고리 페이지에서 카테고리별 전시 목록을 조회할 때, 상단 고정 설정이 반영되지 않은 전시 목록 조회")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "카테고리별 전시 목록 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostInfoByCategoryDtoPage.class)))
+  })
+  @GetMapping("/post/category/{id}")
+  public ResponseEntity<Page<PostInfoByCategoryDto>> getExhibitThumbnailByCategory(
+      Authentication authentication,
+      @Parameter(name = "page", description = "페이지네이션의 페이지 넘버. 0부터 시작함", in = ParameterIn.QUERY)
+      @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+      @Parameter(name = "size", description = "페이지네이션의 페이지당 데이터 수", in = ParameterIn.QUERY)
+      @RequestParam(value = "size", required = false, defaultValue = "20") int size,
+      @Parameter(name = "id", description = "카테고리 ID", in = ParameterIn.PATH) @Valid @PathVariable("id") Long categoryId
+  ) {
+
+    Long userId = getUserId(authentication);
+    return ResponseEntity.ok(
+        exhibitService.getExhibitThumbnailByCategory(userId, categoryId, page, size));
   }
 
   // TODO : 앱 배포했을 때에는 1L 대신에 exception을 던지도록 변경해야 합니다.

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -27,7 +27,6 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpEntity;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -121,10 +120,10 @@ public class ExhibitController {
       @Parameter(name = "direction", description = "페이지네이션의 정렬기준. DESC=최신순, ASC=오래된순", in = ParameterIn.QUERY)
       @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction,
       @PathVariable("id") Long id) {
-    
+
     Long userId = getUserId(authentication);
-    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(id, userId,
-        PageRequest.of(page, size), direction);
+    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(id, userId, page, size,
+        direction);
 
     return ResponseEntity.ok().body(pageResult);
   }
@@ -147,8 +146,8 @@ public class ExhibitController {
       @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction) {
 
     Long userId = getUserId(authentication);
-    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(null, userId,
-        PageRequest.of(page, size), direction);
+    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(null, userId, page, size,
+        direction);
 
     return ResponseEntity.ok().body(pageResult);
   }

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -119,9 +119,10 @@ public class ExhibitController {
       @Parameter(name = "direction", description = "페이지네이션의 정렬기준. DESC=최신순, ASC=오래된순", in = ParameterIn.QUERY)
       @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction,
       @PathVariable("id") Long id) {
+    
     Long userId = getUserId(authentication);
     Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(id, userId,
-        PageRequest.of(page, size, direction, "contents.date"));
+        PageRequest.of(page, size), direction);
 
     return ResponseEntity.ok().body(pageResult);
   }

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -145,8 +145,8 @@ public class ExhibitController {
       @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction) {
 
     Long userId = getUserId(authentication);
-    Page<PostDetailInfo> pageResult = exhibitService.getAllExhibitByPage(userId,
-        PageRequest.of(page, size, direction, "contents.date"));
+    Page<PostDetailInfo> pageResult = exhibitService.getExhibitByPage(null, userId,
+        PageRequest.of(page, size), direction);
 
     return ResponseEntity.ok().body(pageResult);
   }

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
@@ -9,8 +9,11 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -50,11 +53,16 @@ public class Exhibit extends BaseEntity {
   @Embedded
   private Publication publication;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "varchar(32) default 'NONE'")
+  private PinType pinType;
+
   private Exhibit(User user, Category category, ExhibitContents contents, Publication publication) {
     this.user = user;
     this.category = category;
     this.contents = contents;
     this.publication = publication;
+    this.pinType = PinType.NONE;
   }
 
   public Long getId() {
@@ -100,5 +108,13 @@ public class Exhibit extends BaseEntity {
     this.contents = new ExhibitContents(name, contents().getReview(),
         contents().getAttachedLink(), postDate);
     categorize(category);
+  }
+
+  public PinType getPinType() {
+    return this.pinType;
+  }
+
+  public void updatePinType(PinType pinType) {
+    this.pinType = pinType;
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/PinType.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/PinType.java
@@ -1,5 +1,5 @@
 package com.yapp.artie.domain.archive.domain.exhibit;
 
 public enum PinType {
-  NONE, CATEGORY, HOME, BOTH
+  NONE, CATEGORY, ALL, BOTH
 }

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/PinType.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/PinType.java
@@ -1,0 +1,5 @@
+package com.yapp.artie.domain.archive.domain.exhibit;
+
+public enum PinType {
+  NONE, CATEGORY, HOME, BOTH
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostInfoByCategoryDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostInfoByCategoryDto.java
@@ -1,0 +1,25 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@Schema(description = "카테고리 페이지 내 전시 목록 썸네일")
+@RequiredArgsConstructor
+public class PostInfoByCategoryDto {
+
+  @NonNull
+  @Schema(description = "전시 아이디")
+  private Long id;
+
+  @NonNull
+  @Schema(description = "전시명")
+  private String name;
+
+  @NonNull
+  @Schema(description = "대표 이미지")
+  private String mainImage;
+}

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostInfoByCategoryDtoPage.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostInfoByCategoryDtoPage.java
@@ -1,0 +1,13 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import java.util.List;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class PostInfoByCategoryDtoPage extends PageImpl<PostInfoByCategoryDto> {
+
+  public PostInfoByCategoryDtoPage(List<PostInfoByCategoryDto> content,
+      Pageable pageable, long total) {
+    super(content, pageable, total);
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -35,20 +35,20 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   @Query(
       value = "select e from Exhibit e "
           + "where e.user = :user "
-          + "and e.category = :category "
           + "and e.publication.isPublished = true",
       countQuery = "select count(e.id) from Exhibit e"
   )
-  Page<Exhibit> findCategoryExhibitPageBy(Pageable pageable, @Param("user") User user,
-      @Param("category") Category category, JpaSort sort);
+  Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") User user, JpaSort sort);
 
   @Query(
       value = "select e from Exhibit e "
           + "where e.user = :user "
+          + "and e.category = :category "
           + "and e.publication.isPublished = true",
       countQuery = "select count(e.id) from Exhibit e"
   )
-  Page<Exhibit> findAllExhibitPageBy(Pageable pageable, @Param("user") User user);
+  Page<Exhibit> findExhibitByCategoryAsPage(Pageable pageable, @Param("user") User user,
+      @Param("category") Category category, JpaSort sort);
 
   @Query(value = " SELECT p.post_date as date, p.post_id, p.post_num, image. `uri` FROM "
       + "( SELECT post_date, min(id) AS post_id, count(*) post_num FROM post "

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -2,6 +2,7 @@ package com.yapp.artie.domain.archive.repository;
 
 import com.yapp.artie.domain.archive.domain.category.Category;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.domain.exhibit.PinType;
 import com.yapp.artie.domain.archive.dto.exhibit.CalenderQueryResultDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.user.domain.User;
@@ -56,4 +57,10 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
       , nativeQuery = true)
   List<CalenderQueryResultDto> findExhibitAsCalenderByDay(@Param("start") LocalDate start,
       @Param("end") LocalDate end, @Param("user_id") Long userId);
+
+  @Query("SELECT e FROM Exhibit e WHERE e.pinType IN :types AND e.category = :category")
+  Optional<Exhibit> findPinnedExhibitWithCategory(Category category, PinType[] types);
+
+  @Query("SELECT e FROM Exhibit e WHERE e.pinType IN :types")
+  Optional<Exhibit> findPinnedExhibit(PinType[] types);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -34,20 +34,20 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   @Query(
       value = "select e from Exhibit e "
           + "where e.user = :user "
-          + "and e.publication.isPublished = true",
-      countQuery = "select count(e.id) from Exhibit e"
-  )
-  Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") User user);
-
-  @Query(
-      value = "select e from Exhibit e "
-          + "where e.user = :user "
           + "and e.category = :category "
           + "and e.publication.isPublished = true",
       countQuery = "select count(e.id) from Exhibit e"
   )
   Page<Exhibit> findExhibitByCategoryAsPage(Pageable pageable, @Param("user") User user,
       @Param("category") Category category);
+
+  @Query(
+      value = "select e from Exhibit e "
+          + "where e.user = :user "
+          + "and e.publication.isPublished = true",
+      countQuery = "select count(e.id) from Exhibit e"
+  )
+  Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") User user);
 
   @Query(value = " SELECT p.post_date as date, p.post_id, p.post_num, image. `uri` FROM "
       + "( SELECT post_date, min(id) AS post_id, count(*) post_num FROM post "

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -39,7 +40,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
       countQuery = "select count(e.id) from Exhibit e"
   )
   Page<Exhibit> findCategoryExhibitPageBy(Pageable pageable, @Param("user") User user,
-      @Param("category") Category category);
+      @Param("category") Category category, JpaSort sort);
 
   @Query(
       value = "select e from Exhibit e "

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -38,7 +37,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
           + "and e.publication.isPublished = true",
       countQuery = "select count(e.id) from Exhibit e"
   )
-  Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") User user, JpaSort sort);
+  Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") User user);
 
   @Query(
       value = "select e from Exhibit e "
@@ -48,7 +47,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
       countQuery = "select count(e.id) from Exhibit e"
   )
   Page<Exhibit> findExhibitByCategoryAsPage(Pageable pageable, @Param("user") User user,
-      @Param("category") Category category, JpaSort sort);
+      @Param("category") Category category);
 
   @Query(value = " SELECT p.post_date as date, p.post_id, p.post_num, image. `uri` FROM "
       + "( SELECT post_date, min(id) AS post_id, count(*) post_num FROM post "

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -160,6 +160,16 @@ public class ExhibitService {
     }
   }
 
+  public Page<PostInfoByCategoryDto> getExhibitThumbnailByCategory(Long userId, Long categoryId,
+      int page, int size) {
+
+    Category category = categoryService.findCategoryWithUser(categoryId, userId);
+    return exhibitRepository.findExhibitByCategoryAsPage(
+            PageRequest.of(page, size, JpaSort.by(Direction.DESC, "createdAt")),
+            findUser(userId), category)
+        .map(this::buildPostInfoByCategoryDto);
+  }
+
   private User findUser(Long userId) {
     return userService.findById(userId);
   }
@@ -199,6 +209,11 @@ public class ExhibitService {
         .categoryName(exhibit.getCategory().getName())
         .mainImage(imageUri)
         .build();
+  }
+
+  private PostInfoByCategoryDto buildPostInfoByCategoryDto(Exhibit exhibit) {
+    return new PostInfoByCategoryDto(exhibit.getId(), exhibit.contents().getName(),
+        getMainImageUri(exhibit));
   }
 
   private void setExhibitPin(boolean categoryType, Exhibit exhibit) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -70,7 +70,7 @@ public class ExhibitService {
     }
 
     JpaSort sort = JpaSort.unsafe(Direction.ASC,
-            "case when e.pinType in ('BOTH','HOME') then 1 else 2 end")
+            "case when e.pinType in ('BOTH','ALL') then 1 else 2 end")
         .andUnsafe(direction, "createdAt");
     return exhibitRepository.findExhibitAsPage(
             PageRequest.of(page, size, sort), findUser(userId))
@@ -225,16 +225,16 @@ public class ExhibitService {
           exhibit.getCategory(),
           new PinType[]{PinType.BOTH, PinType.CATEGORY});
       pinnedExhibit.ifPresent(value -> value.updatePinType(value
-          .getPinType() == PinType.BOTH ? PinType.HOME : PinType.NONE));
+          .getPinType() == PinType.BOTH ? PinType.ALL : PinType.NONE));
 
-      newPinType = exhibit.getPinType() == PinType.HOME ? PinType.BOTH : PinType.CATEGORY;
+      newPinType = exhibit.getPinType() == PinType.ALL ? PinType.BOTH : PinType.CATEGORY;
     } else {
       Optional<Exhibit> pinnedExhibit = exhibitRepository.findPinnedExhibit(
-          new PinType[]{PinType.BOTH, PinType.HOME});
+          new PinType[]{PinType.BOTH, PinType.ALL});
       pinnedExhibit.ifPresent(value -> value.updatePinType(value
           .getPinType() == PinType.BOTH ? PinType.CATEGORY : PinType.NONE));
 
-      newPinType = exhibit.getPinType() == PinType.CATEGORY ? PinType.BOTH : PinType.HOME;
+      newPinType = exhibit.getPinType() == PinType.CATEGORY ? PinType.BOTH : PinType.ALL;
     }
     exhibit.updatePinType(newPinType);
   }
@@ -242,7 +242,7 @@ public class ExhibitService {
   private void setExhibitNotPin(boolean categoryType, Exhibit exhibit) {
     PinType newPinType;
     if (categoryType) {
-      newPinType = exhibit.getPinType() == PinType.BOTH ? PinType.HOME : PinType.NONE;
+      newPinType = exhibit.getPinType() == PinType.BOTH ? PinType.ALL : PinType.NONE;
     } else {
       newPinType = exhibit.getPinType() == PinType.BOTH ? PinType.CATEGORY : PinType.NONE;
     }

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -8,6 +8,7 @@ import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalenderQueryResultDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
+import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.exception.ExhibitNotFoundException;
@@ -25,7 +26,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.stereotype.Service;
@@ -62,28 +63,29 @@ public class ExhibitService {
     return exhibitRepository.findDraftExhibitDto(findUser(userId));
   }
 
-  public Page<PostDetailInfo> getExhibitByPage(Long categoryId, Long userId, Pageable pageable,
+  public Page<PostDetailInfo> getExhibitByPage(Long categoryId, Long userId, int page, int size,
       Direction direction) {
     if (categoryId != null) {
-      return getExhibitByCategoryAsPage(categoryId, userId, pageable, direction);
+      return getExhibitByCategoryAsPage(categoryId, userId, page, size, direction);
     }
 
     JpaSort sort = JpaSort.unsafe(Direction.ASC,
             "case when e.pinType in ('BOTH','HOME') then 1 else 2 end")
         .andUnsafe(direction, "createdAt");
-    return exhibitRepository.findExhibitAsPage(pageable, findUser(userId), sort)
+    return exhibitRepository.findExhibitAsPage(
+            PageRequest.of(page, size, sort), findUser(userId))
         .map(exhibit -> buildDetailExhibitionInformation(exhibit, getMainImageUri(exhibit)));
   }
 
   public Page<PostDetailInfo> getExhibitByCategoryAsPage(Long categoryId, Long userId,
-      Pageable pageable,
-      Direction direction) {
+      int page, int size, Direction direction) {
 
     Category category = categoryService.findCategoryWithUser(categoryId, userId);
     JpaSort sort = JpaSort.unsafe(Direction.ASC,
             "case when e.pinType in ('BOTH','CATEGORY') then 1 else 2 end")
         .andUnsafe(direction, "createdAt");
-    return exhibitRepository.findExhibitByCategoryAsPage(pageable, findUser(userId), category, sort)
+    return exhibitRepository.findExhibitByCategoryAsPage(PageRequest.of(page, size, sort),
+            findUser(userId), category)
         .map(exhibit -> buildDetailExhibitionInformation(exhibit, getMainImageUri(exhibit)));
   }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -64,16 +64,26 @@ public class ExhibitService {
 
   public Page<PostDetailInfo> getExhibitByPage(Long categoryId, Long userId, Pageable pageable,
       Direction direction) {
+    if (categoryId != null) {
+      return getExhibitByCategoryAsPage(categoryId, userId, pageable, direction);
+    }
+
+    JpaSort sort = JpaSort.unsafe(Direction.ASC,
+            "case when e.pinType in ('BOTH','HOME') then 1 else 2 end")
+        .andUnsafe(direction, "createdAt");
+    return exhibitRepository.findExhibitAsPage(pageable, findUser(userId), sort)
+        .map(exhibit -> buildDetailExhibitionInformation(exhibit, getMainImageUri(exhibit)));
+  }
+
+  public Page<PostDetailInfo> getExhibitByCategoryAsPage(Long categoryId, Long userId,
+      Pageable pageable,
+      Direction direction) {
+
     Category category = categoryService.findCategoryWithUser(categoryId, userId);
     JpaSort sort = JpaSort.unsafe(Direction.ASC,
             "case when e.pinType in ('BOTH','CATEGORY') then 1 else 2 end")
         .andUnsafe(direction, "createdAt");
-    return exhibitRepository.findCategoryExhibitPageBy(pageable, findUser(userId), category, sort)
-        .map(exhibit -> buildDetailExhibitionInformation(exhibit, getMainImageUri(exhibit)));
-  }
-
-  public Page<PostDetailInfo> getAllExhibitByPage(Long userId, Pageable pageable) {
-    return exhibitRepository.findAllExhibitPageBy(pageable, findUser(userId))
+    return exhibitRepository.findExhibitByCategoryAsPage(pageable, findUser(userId), category, sort)
         .map(exhibit -> buildDetailExhibitionInformation(exhibit, getMainImageUri(exhibit)));
   }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,9 +62,13 @@ public class ExhibitService {
     return exhibitRepository.findDraftExhibitDto(findUser(userId));
   }
 
-  public Page<PostDetailInfo> getExhibitByPage(Long id, Long userId, Pageable pageable) {
-    Category category = categoryService.findCategoryWithUser(id, userId);
-    return exhibitRepository.findCategoryExhibitPageBy(pageable, findUser(userId), category)
+  public Page<PostDetailInfo> getExhibitByPage(Long categoryId, Long userId, Pageable pageable,
+      Direction direction) {
+    Category category = categoryService.findCategoryWithUser(categoryId, userId);
+    JpaSort sort = JpaSort.unsafe(Direction.ASC,
+            "case when e.pinType in ('BOTH','CATEGORY') then 1 else 2 end")
+        .andUnsafe(direction, "createdAt");
+    return exhibitRepository.findCategoryExhibitPageBy(pageable, findUser(userId), category, sort)
         .map(exhibit -> buildDetailExhibitionInformation(exhibit, getMainImageUri(exhibit)));
   }
 

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -291,7 +291,6 @@ class ExhibitServiceTest {
   @Test
   public void getExhibitByPage_상단고정포함_카테고리_전시목록() {
     User user = createUser("user", "tu");
-    int cnt = exhibitRepository.findAll().size();
     Category defaultCategory = categoryService.findCategoryWithUser(
         categoryService.categoriesOf(user.getId()).get(0).getId(), user.getId());
     Exhibit exhibit = exhibitRepository.save(
@@ -322,7 +321,6 @@ class ExhibitServiceTest {
   @Test
   public void getExhibitByPage_상단고정포함_전체_전시목록() {
     User user = createUser("user", "tu");
-    int cnt = exhibitRepository.findAll().size();
     Category defaultCategory = categoryService.findCategoryWithUser(
         categoryService.categoriesOf(user.getId()).get(0).getId(), user.getId());
     Exhibit exhibit = exhibitRepository.save(
@@ -337,9 +335,8 @@ class ExhibitServiceTest {
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), false, true);
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), true, true);
 
-    Page<PostDetailInfo> results = exhibitService.getExhibitByPage(defaultCategory.getId(),
-        user.getId(), PageRequest.of(0, 5),
-        Direction.DESC);
+    Page<PostDetailInfo> results = exhibitService.getExhibitByPage(null, user.getId(),
+        PageRequest.of(0, 5), Direction.DESC);
 
     assertThat(exhibit.getPinType()).isEqualTo(PinType.BOTH);
     assertThat(results.getSize()).isEqualTo(5);

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -214,7 +214,7 @@ class ExhibitServiceTest {
   }
 
   @Test
-  public void updatePostPinType_전체기록_상단_설정_BOTH_TO_HOME() {
+  public void updatePostPinType_전체기록_상단_설정_BOTH_TO_ALL() {
     User user = createUser("user", "tu");
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
@@ -230,7 +230,7 @@ class ExhibitServiceTest {
     Optional<Exhibit> exhibit1 = exhibitRepository.findExhibitEntityGraphById(exhibitId1);
     Optional<Exhibit> exhibit2 = exhibitRepository.findExhibitEntityGraphById(exhibitId2);
     assertThat(exhibit1.isPresent()).isTrue();
-    assertThat(exhibit1.get().getPinType()).isEqualTo(PinType.HOME);
+    assertThat(exhibit1.get().getPinType()).isEqualTo(PinType.ALL);
     assertThat(exhibit2.isPresent()).isTrue();
     assertThat(exhibit2.get().getPinType()).isEqualTo(PinType.CATEGORY);
   }
@@ -289,7 +289,7 @@ class ExhibitServiceTest {
 
     Optional<Exhibit> exhibit1 = exhibitRepository.findExhibitEntityGraphById(exhibitId1);
     assertThat(exhibit1.isPresent()).isTrue();
-    assertThat(exhibit1.get().getPinType()).isEqualTo(PinType.HOME);
+    assertThat(exhibit1.get().getPinType()).isEqualTo(PinType.ALL);
   }
 
   @Test

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -12,6 +12,7 @@ import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
+import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.exception.ExhibitAlreadyPublishedException;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -310,8 +310,7 @@ class ExhibitServiceTest {
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), true, true);
 
     Page<PostDetailInfo> results = exhibitService.getExhibitByPage(defaultCategory.getId(),
-        user.getId(), PageRequest.of(0, 5),
-        Direction.DESC);
+        user.getId(), 0, 5, Direction.DESC);
 
     assertThat(exhibit.getPinType()).isEqualTo(PinType.BOTH);
     assertThat(results.getSize()).isEqualTo(5);
@@ -340,7 +339,7 @@ class ExhibitServiceTest {
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), true, true);
 
     Page<PostDetailInfo> results = exhibitService.getExhibitByPage(null, user.getId(),
-        PageRequest.of(0, 5), Direction.DESC);
+        0, 5, Direction.DESC);
 
     assertThat(exhibit.getPinType()).isEqualTo(PinType.BOTH);
     assertThat(results.getSize()).isEqualTo(5);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,9 +9,23 @@ spring:
       hibernate:
         auto_quote_keyword: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 logging:
   level:
     org.hibernate.sql: debug
     org.hibernate.type: trace
+
+cloud:
+  aws:
+    credentials:
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+      access-key: ${AWS_ACCESS_KEY_ID}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    cloudfront:
+      domain: ${AWS_CDN_DOMAIN}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,7 +9,7 @@ spring:
       hibernate:
         auto_quote_keyword: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
 
 logging:
   level:


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 상단 고정 설정 API 추가
- 홈 화면 조회 API(전체, 카테고리)의 상단 고정 적용
- 홈 화면 조회 API 하나로 통합
- 카테고리별 전시 목록 조회 API 추가 : 카테고리 페이지의 전시 목록은 상단 고정이 반영되어서는 안되므로 별도의 API가 필요함

**자세한 내용, 리뷰 확인 부탁드립니다.**

## 관련 이슈

close #72, #77

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




