### PR TITLE
캘린더 페이지 내 일자별 전시 목록 조회 API 수정, 특정 날짜 전시 목록 조회 API 추가 및 기타 버그 수정

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -5,6 +5,7 @@ import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitResponseDto;
+import com.yapp.artie.domain.archive.dto.exhibit.ExhibitByDateResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfoPage;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDto;
@@ -296,6 +297,28 @@ public class ExhibitController {
     Long userId = getUserId(authentication);
     return ResponseEntity.ok(
         exhibitService.getExhibitThumbnailByCategory(userId, categoryId, page, size));
+  }
+
+  @Operation(summary = "특정 날짜의 전시 정보 목록 조회(캘린더 페이지)", description = "캘린더 페이지에서 특정 날짜를 클릭했을 때, 해당 날짜의 전시가 여러개일 경우, 전시 목록을 조회할 수 있도록 정보를 반환하는 API")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "특정 날짜의 전시 정보 목록 반환",
+          content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ExhibitByDateResponseDto.class)))
+      )
+  })
+  @GetMapping("/date")
+  public ResponseEntity<List<ExhibitByDateResponseDto>> getExhibitsByDate(
+      Authentication authentication,
+      @Parameter(name = "year", description = "조회할 연도", in = ParameterIn.QUERY, example = "2023")
+      @RequestParam(value = "year", required = true) int year,
+      @Parameter(name = "month", description = "조회할 달", in = ParameterIn.QUERY, example = "1")
+      @RequestParam(value = "month", required = true) int month,
+      @Parameter(name = "day", description = "조회할 일", in = ParameterIn.QUERY, example = "1")
+      @RequestParam(value = "day", required = true) int day
+  ) {
+
+    Long userId = getUserId(authentication);
+    return ResponseEntity.ok(
+        exhibitService.getExhibitsByDate(userId, year, month, day));
   }
 
   // TODO : 앱 배포했을 때에는 1L 대신에 exception을 던지도록 변경해야 합니다.

--- a/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
+++ b/src/main/java/com/yapp/artie/domain/archive/controller/ExhibitController.java
@@ -284,7 +284,7 @@ public class ExhibitController {
       @ApiResponse(
           responseCode = "200", description = "카테고리별 전시 목록 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PostInfoByCategoryDtoPage.class)))
   })
-  @GetMapping("/post/category/{id}")
+  @GetMapping("/category/{id}")
   public ResponseEntity<Page<PostInfoByCategoryDto>> getExhibitThumbnailByCategory(
       Authentication authentication,
       @Parameter(name = "page", description = "페이지네이션의 페이지 넘버. 0부터 시작함", in = ParameterIn.QUERY)

--- a/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/artwork/CreateArtworkRequestDto.java
@@ -36,4 +36,9 @@ public class CreateArtworkRequestDto {
   @Valid
   @Schema(description = "작품 할당 태그")
   private List<CreateArtworkTagDto> tags = new ArrayList<>();
+
+  public CreateArtworkRequestDto(Long postId, String imageUri) {
+    this.postId = postId;
+    this.imageUri = imageUri;
+  }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
@@ -24,4 +24,7 @@ public class CalendarExhibitResponseDto {
 
   @Schema(description = "대표 이미지")
   private final String imageURL;
+
+  @Schema(description = "해당 날짜의 전시 수")
+  private final Long postNum;
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
@@ -22,6 +22,10 @@ public class CalendarExhibitResponseDto {
   @Schema(description = "일(day)", required = true)
   private final int day;
 
+  @NonNull
+  @Schema(description = "전시 ID", required = true)
+  private final Long postId;
+
   @Schema(description = "대표 이미지")
   private final String imageURL;
 

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalenderQueryResultDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalenderQueryResultDto.java
@@ -3,11 +3,11 @@ package com.yapp.artie.domain.archive.dto.exhibit;
 /* 주어진 기간 동안의 일별 전시 정보, 같은 날에 등록된 전시가 여러개라면, 가장 먼저 등록된 전시 정보를 반환함. */
 public interface CalenderQueryResultDto {
 
-  String getDate();
+  String getCalenderDate();
 
   Long getPostId();
 
-  Integer getPostNum();
+  Long getPostNum();
 
   String getUri();
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/ExhibitByDateResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/ExhibitByDateResponseDto.java
@@ -1,0 +1,20 @@
+package com.yapp.artie.domain.archive.dto.exhibit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "특정 날짜의 전시 목록 조회 Response")
+@RequiredArgsConstructor
+public class ExhibitByDateResponseDto {
+
+  @NonNull
+  @Schema(description = "전시 ID", required = true)
+  private final Long postId;
+
+  @NonNull
+  @Schema(description = "전시 이름", required = true)
+  private final String postName;
+}

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -6,13 +6,14 @@ import com.yapp.artie.domain.archive.domain.exhibit.PinType;
 import com.yapp.artie.domain.archive.dto.exhibit.CalenderQueryResultDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.user.domain.User;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -49,18 +50,23 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   )
   Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") User user);
 
-  @Query(value = " SELECT p.post_date as date, p.post_id, p.post_num, image. `uri` FROM "
-      + "( SELECT post_date, min(id) AS post_id, count(*) post_num FROM post "
-      + "WHERE post_date BETWEEN :start AND :end AND user_id = :user_id "
-      + "GROUP BY post_date ORDER BY post_date ASC) AS p "
-      + "LEFT OUTER JOIN image ON p.post_id = image.post_id AND image.is_main_image = TRUE"
+  @Query(value = "SELECT p.calenderDate, p.postId, p.postNum, image. `uri` FROM "
+      + "( SELECT DATE(created_at) as calenderDate, MAX(id) AS postId, count(*) postNum FROM post "
+      + "WHERE created_at BETWEEN :start AND :end AND user_id = :user_id AND is_published = true "
+      + "GROUP BY calenderDate ORDER BY calenderDate ASC) AS p "
+      + "LEFT OUTER JOIN image ON p.postId = image.post_id AND image.is_main_image = TRUE"
       , nativeQuery = true)
-  List<CalenderQueryResultDto> findExhibitAsCalenderByDay(@Param("start") LocalDate start,
-      @Param("end") LocalDate end, @Param("user_id") Long userId);
+  List<CalenderQueryResultDto> findExhibitAsCalenderByDay(@Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end, @Param("user_id") Long userId);
 
   @Query("SELECT e FROM Exhibit e WHERE e.pinType IN :types AND e.category = :category")
   Optional<Exhibit> findPinnedExhibitWithCategory(Category category, PinType[] types);
 
   @Query("SELECT e FROM Exhibit e WHERE e.pinType IN :types")
   Optional<Exhibit> findPinnedExhibit(PinType[] types);
+
+  @Modifying(clearAutomatically = true)
+  @Query("update Exhibit e set e.createdAt = :createdAt where e.id = :exhibitId")
+  void updateExhibitCreatedAt(@Param("createdAt") LocalDateTime createdAt,
+      @Param("exhibitId") Long exhibitId);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -4,6 +4,7 @@ import com.yapp.artie.domain.archive.domain.category.Category;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.domain.exhibit.PinType;
 import com.yapp.artie.domain.archive.dto.exhibit.CalenderQueryResultDto;
+import com.yapp.artie.domain.archive.dto.exhibit.ExhibitByDateResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.user.domain.User;
 import java.time.LocalDateTime;
@@ -69,4 +70,13 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   @Query("update Exhibit e set e.createdAt = :createdAt where e.id = :exhibitId")
   void updateExhibitCreatedAt(@Param("createdAt") LocalDateTime createdAt,
       @Param("exhibitId") Long exhibitId);
+
+  @Query(
+      "SELECT NEW com.yapp.artie.domain.archive.dto.exhibit.ExhibitByDateResponseDto(e.id, e.contents.name) FROM Exhibit e "
+          + "WHERE e.createdAt BETWEEN :start AND :end "
+          + "AND e.user = :user AND e.publication.isPublished = true "
+          + "ORDER BY e.createdAt DESC")
+  List<ExhibitByDateResponseDto> findExhibitsByDate(@Param("user") User user,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -20,6 +20,7 @@ import com.yapp.artie.domain.user.service.UserService;
 import com.yapp.artie.global.util.DateUtils;
 import com.yapp.artie.global.util.S3Utils;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
@@ -90,9 +91,12 @@ public class ExhibitService {
       CalendarExhibitRequestDto calendarExhibitRequestDto, Long userId) {
     int year = calendarExhibitRequestDto.getYear();
     int month = calendarExhibitRequestDto.getMonth();
-    return exhibitRepository.findExhibitAsCalenderByDay(
-            DateUtils.getFirstDayOf(year, month),
-            DateUtils.getLastDayOf(year, month), userId).stream()
+
+    LocalDateTime start = DateUtils.getFirstDayOf(year, month);
+    LocalDateTime end = DateUtils.getLastDayOf(year, month);
+
+    return exhibitRepository.findExhibitAsCalenderByDay(start, end, userId)
+        .stream()
         .map(this::buildCalendarExhibitInformation).collect(
             Collectors.toList());
   }
@@ -187,10 +191,10 @@ public class ExhibitService {
 
   private CalendarExhibitResponseDto buildCalendarExhibitInformation(
       CalenderQueryResultDto queryResult) {
-    LocalDate date = LocalDate.parse(queryResult.getDate(), DateTimeFormatter.ISO_DATE);
+    LocalDate date = LocalDate.parse(queryResult.getCalenderDate(), DateTimeFormatter.ISO_DATE);
     return new CalendarExhibitResponseDto(date.getYear(),
         date.getMonthValue(), date.getDayOfMonth(),
-        s3Utils.getFullUri(queryResult.getUri()));
+        s3Utils.getFullUri(queryResult.getUri()), queryResult.getPostNum());
   }
 
   private PostInfoDto buildExhibitionInformation(Exhibit exhibit) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -193,7 +193,7 @@ public class ExhibitService {
       CalenderQueryResultDto queryResult) {
     LocalDate date = LocalDate.parse(queryResult.getCalenderDate(), DateTimeFormatter.ISO_DATE);
     return new CalendarExhibitResponseDto(date.getYear(),
-        date.getMonthValue(), date.getDayOfMonth(),
+        date.getMonthValue(), date.getDayOfMonth(), queryResult.getPostId(),
         s3Utils.getFullUri(queryResult.getUri()), queryResult.getPostNum());
   }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -7,6 +7,7 @@ import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalenderQueryResultDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
+import com.yapp.artie.domain.archive.dto.exhibit.ExhibitByDateResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
@@ -117,6 +118,14 @@ public class ExhibitService {
             PageRequest.of(page, size, JpaSort.by(Direction.DESC, "createdAt")),
             findUser(userId), category)
         .map(this::buildPostInfoByCategoryDto);
+  }
+
+  public List<ExhibitByDateResponseDto> getExhibitsByDate(Long userId, int year, int month,
+      int day) {
+
+    LocalDateTime start = DateUtils.getStartTimeOf(year, month, day);
+    LocalDateTime end = DateUtils.getEndTimeOf(year, month, day);
+    return exhibitRepository.findExhibitsByDate(findUser(userId), start, end);
   }
 
   @Transactional

--- a/src/main/java/com/yapp/artie/global/util/DateUtils.java
+++ b/src/main/java/com/yapp/artie/global/util/DateUtils.java
@@ -15,6 +15,14 @@ public class DateUtils {
     return YearMonth.of(year, monthOf(month)).atEndOfMonth().atTime(LocalTime.MAX);
   }
 
+  public static LocalDateTime getStartTimeOf(int year, int month, int day) {
+    return YearMonth.of(year, monthOf(month)).atDay(day).atStartOfDay();
+  }
+
+  public static LocalDateTime getEndTimeOf(int year, int month, int day) {
+    return YearMonth.of(year, monthOf(month)).atDay(day).atTime(LocalTime.MAX);
+  }
+
   private static Month monthOf(int month) {
     return Month.of(month);
   }

--- a/src/main/java/com/yapp/artie/global/util/DateUtils.java
+++ b/src/main/java/com/yapp/artie/global/util/DateUtils.java
@@ -1,17 +1,18 @@
 package com.yapp.artie.global.util;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.Month;
 import java.time.YearMonth;
 
 public class DateUtils {
 
-  public static LocalDate getFirstDayOf(int year, int month) {
-    return YearMonth.of(year, monthOf(month)).atDay(1);
+  public static LocalDateTime getFirstDayOf(int year, int month) {
+    return YearMonth.of(year, monthOf(month)).atDay(1).atStartOfDay();
   }
 
-  public static LocalDate getLastDayOf(int year, int month) {
-    return YearMonth.of(year, monthOf(month)).atEndOfMonth();
+  public static LocalDateTime getLastDayOf(int year, int month) {
+    return YearMonth.of(year, monthOf(month)).atEndOfMonth().atTime(LocalTime.MAX);
   }
 
   private static Month monthOf(int month) {

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -10,8 +10,6 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: create
-      show_sql: true
-      format_sql: true
   
   logging.level:
     org.hibernate.SQL: debug

--- a/src/test/java/com/yapp/artie/DateUtilTest.java
+++ b/src/test/java/com/yapp/artie/DateUtilTest.java
@@ -1,7 +1,7 @@
 package com.yapp.artie;
 
 import com.yapp.artie.global.util.DateUtils;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import org.assertj.core.api.Assertions;
@@ -10,13 +10,13 @@ import org.junit.jupiter.api.Test;
 public class DateUtilTest {
 
   @Test
-  public void test_local_date_동등성_비교() throws Exception {
+  public void test_local_date_time_동등성_비교() throws Exception {
     //given
-    HashMap<LocalDate, Integer> hash = new HashMap<>();
-    HashSet<LocalDate> set = new HashSet<>();
+    HashMap<LocalDateTime, Integer> hash = new HashMap<>();
+    HashSet<LocalDateTime> set = new HashSet<>();
 
-    LocalDate test1 = DateUtils.getFirstDayOf(2023, 12);
-    LocalDate test2 = DateUtils.getFirstDayOf(2023, 12);
+    LocalDateTime test1 = DateUtils.getFirstDayOf(2023, 12);
+    LocalDateTime test2 = DateUtils.getFirstDayOf(2023, 12);
 
     //when
     hash.put(test1, 1);

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -12,6 +12,7 @@ import com.yapp.artie.domain.archive.dto.cateogry.CreateCategoryRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitRequestDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CalendarExhibitResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
+import com.yapp.artie.domain.archive.dto.exhibit.ExhibitByDateResponseDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostDetailInfo;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoByCategoryDto;
 import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
@@ -399,6 +400,27 @@ class ExhibitServiceTest {
     assertThat(results.getNumber()).isEqualTo(0);
     assertThat(results.getContent().get(0).getId()).isNotEqualTo(exhibit.getId());
     assertThat(results.getContent().get(0).getName()).isEqualTo("test-10");
+  }
+
+
+  @Test
+  public void getExhibitsByDate_특정_일자의_전시_목록_조회() throws Exception {
+    User user = createUser("user", "tu");
+    Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
+
+    for (int i = 1; i <= 2; i++) {
+      exhibitRepository.save(
+              Exhibit.create(String.format("test-%d", i), LocalDate.now(), defaultCategory, user))
+          .publish();
+    }
+
+    List<ExhibitByDateResponseDto> results = exhibitService.getExhibitsByDate(
+        user.getId(), LocalDate.now().getYear(), LocalDate.now().getMonthValue(), LocalDate.now()
+            .getDayOfMonth());
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.get(0).getPostId()).isEqualTo(2L);
+    assertThat(results.get(0).getPostName()).isEqualTo("test-2");
   }
 }
 

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -203,6 +203,7 @@ class ExhibitServiceTest {
     assertThat(results.get(0).getMonth()).isEqualTo(1);
     assertThat(results.get(0).getDay()).isEqualTo(1);
     assertThat(results.get(0).getPostNum()).isEqualTo(2);
+    assertThat(results.get(0).getPostId()).isEqualTo(5L);
     assertThat(results.get(1).getDay()).isEqualTo(2);
   }
 

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -3,6 +3,7 @@ package com.yapp.artie.domain.archive.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yapp.artie.domain.archive.domain.artwork.Artwork;
 import com.yapp.artie.domain.archive.domain.category.Category;
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.archive.domain.exhibit.PinType;
@@ -17,12 +18,14 @@ import com.yapp.artie.domain.archive.dto.exhibit.PostInfoDto;
 import com.yapp.artie.domain.archive.dto.exhibit.UpdateExhibitRequestDto;
 import com.yapp.artie.domain.archive.exception.ExhibitAlreadyPublishedException;
 import com.yapp.artie.domain.archive.exception.NotOwnerOfCategoryException;
+import com.yapp.artie.domain.archive.repository.ArtworkRepository;
 import com.yapp.artie.domain.archive.repository.CategoryRepository;
 import com.yapp.artie.domain.archive.repository.ExhibitRepository;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.repository.UserRepository;
 import java.time.LocalDate;
-import java.time.Month;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +56,9 @@ class ExhibitServiceTest {
 
   @Autowired
   CategoryRepository categoryRepository;
+
+  @Autowired
+  ArtworkRepository artworkRepository;
 
   @Autowired
   ExhibitService exhibitService;
@@ -173,23 +179,31 @@ class ExhibitServiceTest {
   @Test
   public void getExhibitByMonthly_월_별로_전시를_조회한다() throws Exception {
     User user = createUser("user", "tu");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
 
-    for (int i = 1; i <= 12; i++) {
-      CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-          defaultCateogry.getId(),
-          LocalDate.of(2023, Month.of(i), 1));
-      exhibitService.create(exhibitRequestDto, user.getId());
+    for (int i = 1; i <= 5; i++) {
+      Exhibit exhibit = Exhibit.create("test", LocalDate.now(), defaultCategory, user);
+      exhibitRepository.save(exhibit);
+      exhibit.publish();
+      LocalDateTime mockedCreatedAt = i < 5 ?
+          YearMonth.of(2023, 1).atDay(i).atStartOfDay()
+          : YearMonth.of(2023, 1).atDay(1).atTime(9, 0);
+      exhibitRepository.updateExhibitCreatedAt(mockedCreatedAt, exhibit.getId());
+      artworkRepository.save(
+          Artwork.create(exhibit, true, null, null, String.format("test-%d", i)));
     }
 
-    for (int i = 1; i <= 12; i++) {
-      CalendarExhibitRequestDto calendarExhibitRequestDto = new CalendarExhibitRequestDto(2023, i);
-      List<CalendarExhibitResponseDto> exhibitByMonthly = exhibitService.getExhibitByMonthly(
-          calendarExhibitRequestDto,
-          user.getId());
+    List<CalendarExhibitResponseDto> results = exhibitService.getExhibitByMonthly(
+        new CalendarExhibitRequestDto(2023, 1),
+        user.getId());
 
-      assertThat(exhibitByMonthly.size()).isEqualTo(1);
-    }
+    assertThat(results.size()).isEqualTo(4);
+    assertThat(results.get(0).getImageURL().endsWith("test-5")).isTrue();
+    assertThat(results.get(0).getYear()).isEqualTo(2023);
+    assertThat(results.get(0).getMonth()).isEqualTo(1);
+    assertThat(results.get(0).getDay()).isEqualTo(1);
+    assertThat(results.get(0).getPostNum()).isEqualTo(2);
+    assertThat(results.get(1).getDay()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 캘린더 페이지의 특정 월의 일자별 전시 목록 조회 API
  - createdAt 기준 정렬되도록 변경
  - 등록 오래된 순 -> 최신순으로 변경
  - 해당 날짜의 전시 수 필드 및 관련 로직 추가
  - 해당 전시의 post ID 필드 및 관련 로직 추가
- 캘린더 페이지의 특정 날짜의 전시 목록 조회 API 추가
- 카테고리별 전시 목록 반환 API URI 수정
  - /post/post/category/{id}로 설정되어있는 버그 개선
- DateUtil내 메소드가 LocalDate가 아닌 LocalDateTime을 다루도록 수정

## 관련 이슈

close #79 
close #87 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




