### PR TITLE
마이 페이지 공지사항 기능 구현

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/domain/category/Category.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/category/Category.java
@@ -28,12 +28,6 @@ public class Category extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private Category(User user, String name, int sequence) {
-    this.user = user;
-    this.name = name;
-    this.sequence = sequence;
-  }
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
@@ -46,6 +40,12 @@ public class Category extends BaseEntity {
 
   @Column(nullable = false, name = "seq")
   private int sequence;
+
+  private Category(User user, String name, int sequence) {
+    this.user = user;
+    this.name = name;
+    this.sequence = sequence;
+  }
 
   public static Category create(User user, String name, int sequence) {
     return new Category(user, name, sequence);

--- a/src/main/java/com/yapp/artie/domain/archive/dto/cateogry/CategoryDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/cateogry/CategoryDto.java
@@ -11,13 +11,13 @@ import lombok.NoArgsConstructor;
 public class CategoryDto {
 
   @Schema(description = "카테고리 아이디")
-  private  Long id;
+  private Long id;
 
   @Schema(description = "카테고리 명")
-  private  String name;
+  private String name;
 
   @Schema(description = "카테고리 순서")
-  private  int sequence;
+  private int sequence;
 
   public CategoryDto(Long id, String name, int sequence) {
     this.id = id;

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -22,6 +22,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
 
+  @Query("select count(e.id) from Exhibit e "
+      + "where e.user = :user "
+      + "and  e.publication.isPublished = true")
+  int countExhibit(@Param("user") User user);
+
   @EntityGraph(attributePaths = {"user"})
   Optional<Exhibit> findExhibitEntityGraphById(Long id);
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -46,6 +46,10 @@ public class ExhibitService {
   private final CategoryService categoryService;
   private final S3Utils s3Utils;
 
+  public int getExhibitCount(Long userId) {
+    return exhibitRepository.countExhibit(findUser(userId));
+  }
+
   public PostInfoDto getExhibitInformation(Long id, Long userId) {
     Exhibit exhibit = exhibitRepository.findExhibitEntityGraphById(id)
         .orElseThrow(ExhibitNotFoundException::new);
@@ -191,7 +195,6 @@ public class ExhibitService {
         .map(artwork -> s3Utils.getFullUri(artwork.getContents().getUri())).orElse(null);
   }
   // TODO : public이 아니도록 수정
-
   public void validateOwnedByUser(User user, Exhibit exhibit) {
     if (!exhibit.ownedBy(user)) {
       throw new NotOwnerOfExhibitException();

--- a/src/main/java/com/yapp/artie/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yapp/artie/domain/notice/controller/NoticeController.java
@@ -1,6 +1,7 @@
 package com.yapp.artie.domain.notice.controller;
 
 
+import com.yapp.artie.domain.notice.dto.NoticeDetailInfo;
 import com.yapp.artie.domain.notice.dto.NoticeDto;
 import com.yapp.artie.domain.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,5 +35,17 @@ public class NoticeController {
   @GetMapping()
   public ResponseEntity<List<NoticeDto>> getNotices() {
     return ResponseEntity.ok(noticeService.notices());
+  }
+
+  @Operation(summary = "공지사항 상세 조회", description = "특정 공지사항 상세를 조회")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "공지사항 상세가 성공적으로 조회됨",
+          content = @Content(mediaType = "application/json", schema =  @Schema(implementation = NoticeDetailInfo.class))),
+  })
+  @GetMapping("/{id}")
+  public ResponseEntity<NoticeDetailInfo> getNoticeDetail(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(noticeService.notice(id));
   }
 }

--- a/src/main/java/com/yapp/artie/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yapp/artie/domain/notice/controller/NoticeController.java
@@ -1,0 +1,37 @@
+package com.yapp.artie.domain.notice.controller;
+
+
+import com.yapp.artie.domain.notice.dto.NoticeDto;
+import com.yapp.artie.domain.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/notice")
+@RequiredArgsConstructor
+@RestController
+public class NoticeController {
+
+  private final NoticeService noticeService;
+
+  @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "공지사항 목록이 성공적으로 조회됨",
+          content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = NoticeDto.class)))),
+  })
+  @GetMapping()
+  public ResponseEntity<List<NoticeDto>> getNotices() {
+    return ResponseEntity.ok(noticeService.notices());
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/notice/domain/Notice.java
+++ b/src/main/java/com/yapp/artie/domain/notice/domain/Notice.java
@@ -29,4 +29,14 @@ public class Notice {
   @Column(nullable = false, updatable = false)
   @CreatedDate
   private LocalDateTime createdAt;
+
+  private Notice(String title, String contents) {
+    this.title = title;
+    this.contents = contents;
+    this.createdAt = LocalDateTime.now();
+  }
+
+  public static Notice create(String title, String contents) {
+    return new Notice(title, contents);
+  }
 }

--- a/src/main/java/com/yapp/artie/domain/notice/dto/NoticeDetailInfo.java
+++ b/src/main/java/com/yapp/artie/domain/notice/dto/NoticeDetailInfo.java
@@ -1,0 +1,32 @@
+package com.yapp.artie.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "공지사항 상세 Response")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeDetailInfo {
+
+  @Schema(description = "공지사항 아이디")
+  private Long id;
+
+  @Schema(description = "공지일")
+  private LocalDateTime date;
+
+  @Schema(description = "공지사항 제목")
+  private String title;
+
+  @Schema(description = "공지 내용")
+  private String contents;
+
+  public NoticeDetailInfo(Long id, LocalDateTime date, String title, String contents) {
+    this.id = id;
+    this.date = date;
+    this.title = title;
+    this.contents = contents;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/notice/dto/NoticeDto.java
+++ b/src/main/java/com/yapp/artie/domain/notice/dto/NoticeDto.java
@@ -1,0 +1,28 @@
+package com.yapp.artie.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "공지사항 Response")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeDto {
+
+  @Schema(description = "공지사항 아이디")
+  private Long id;
+
+  @Schema(description = "공지일")
+  private LocalDateTime date;
+
+  @Schema(description = "공지사항 제목")
+  private String title;
+
+  public NoticeDto(Long id, LocalDateTime date, String title) {
+    this.id = id;
+    this.date = date;
+    this.title = title;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/yapp/artie/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.yapp.artie.domain.notice.exception;
+
+import com.yapp.artie.global.exception.common.BusinessException;
+import com.yapp.artie.global.exception.response.ErrorCode;
+
+public class NoticeNotFoundException extends BusinessException {
+
+  public NoticeNotFoundException() {
+    super(ErrorCode.NOTICE_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/yapp/artie/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,15 @@
+package com.yapp.artie.domain.notice.repository;
+
+import com.yapp.artie.domain.notice.domain.Notice;
+import com.yapp.artie.domain.notice.dto.NoticeDto;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+  @Query("select new com.yapp.artie.domain.notice.dto.NoticeDto(n.id, n.createdAt, n.title) from Notice n")
+  List<NoticeDto> findNoticeDto();
+}

--- a/src/main/java/com/yapp/artie/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yapp/artie/domain/notice/service/NoticeService.java
@@ -1,6 +1,9 @@
 package com.yapp.artie.domain.notice.service;
 
+import com.yapp.artie.domain.notice.domain.Notice;
+import com.yapp.artie.domain.notice.dto.NoticeDetailInfo;
 import com.yapp.artie.domain.notice.dto.NoticeDto;
+import com.yapp.artie.domain.notice.exception.NoticeNotFoundException;
 import com.yapp.artie.domain.notice.repository.NoticeRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,5 +19,15 @@ public class NoticeService {
 
   public List<NoticeDto> notices() {
     return noticeRepository.findNoticeDto();
+  }
+
+  public NoticeDetailInfo notice(Long id) {
+    Notice notice = noticeRepository.findById(id).orElseThrow(NoticeNotFoundException::new);
+    return new NoticeDetailInfo(
+        notice.getId(),
+        notice.getCreatedAt(),
+        notice.getTitle(),
+        notice.getContents()
+    );
   }
 }

--- a/src/main/java/com/yapp/artie/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yapp/artie/domain/notice/service/NoticeService.java
@@ -1,0 +1,20 @@
+package com.yapp.artie.domain.notice.service;
+
+import com.yapp.artie.domain.notice.dto.NoticeDto;
+import com.yapp.artie.domain.notice.repository.NoticeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NoticeService {
+
+  private final NoticeRepository noticeRepository;
+
+  public List<NoticeDto> notices() {
+    return noticeRepository.findNoticeDto();
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -3,7 +3,9 @@ package com.yapp.artie.domain.user.controller;
 import com.google.firebase.auth.FirebaseToken;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
+import com.yapp.artie.domain.user.dto.response.UserThumbnailResponseDto;
 import com.yapp.artie.domain.user.service.UserService;
+import com.yapp.artie.domain.user.service.UserThumbnailService;
 import com.yapp.artie.global.authentication.JwtService;
 import com.yapp.artie.global.exception.common.InvalidValueException;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserService userService;
+  private final UserThumbnailService userThumbnailService;
   private final JwtService jwtService;
 
   @Operation(summary = "유저 생성", description = "Firebase를 통해 생성한 UID 기반 유저 생성")
@@ -64,6 +67,20 @@ public class UserController {
     User user = userService.findById(userId);
 
     return ResponseEntity.ok().body(user);
+  }
+
+  @Operation(summary = "마이페이지 썸네일 조회", description = "사용자 닉네임, 전시 개수 조회")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "썸네일이 성공적으로 조회됨",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
+  })
+  @GetMapping("/my-page")
+  public ResponseEntity<UserThumbnailResponseDto> my(Authentication authentication) {
+    // Long userId = Long.parseLong(authentication.getName());
+    Long userId = 1L;
+    return ResponseEntity.ok().body(userThumbnailService.getUserThumbnail(userId));
   }
 
   private void validateUidWithToken(String uid, FirebaseToken decodedToken) {

--- a/src/main/java/com/yapp/artie/domain/user/dto/response/UserThumbnailResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/user/dto/response/UserThumbnailResponseDto.java
@@ -1,0 +1,23 @@
+package com.yapp.artie.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "마이 페이지 조회 Response")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserThumbnailResponseDto {
+
+  @Schema(description = "사용자 이름")
+  private String name;
+
+  @Schema(description = "전시 개수")
+  private int exhibitCount;
+
+  public UserThumbnailResponseDto(String name, int exhibitCount) {
+    this.name = name;
+    this.exhibitCount = exhibitCount;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/user/service/UserThumbnailService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserThumbnailService.java
@@ -1,0 +1,24 @@
+package com.yapp.artie.domain.user.service;
+
+
+import com.yapp.artie.domain.archive.service.ExhibitService;
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.dto.response.UserThumbnailResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserThumbnailService {
+
+  private final UserService userService;
+  private final ExhibitService exhibitService;
+
+  public UserThumbnailResponseDto getUserThumbnail(Long id) {
+    User user = userService.findById(id);
+    int exhibitCount = exhibitService.getExhibitCount(user.getId());
+    return new UserThumbnailResponseDto(user.getName(), exhibitCount);
+  }
+}

--- a/src/main/java/com/yapp/artie/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/yapp/artie/global/config/swagger/SwaggerConfig.java
@@ -75,6 +75,17 @@ public class SwaggerConfig {
   }
 
   @Bean
+  public GroupedOpenApi noticeApi() {
+    String[] paths = {"/notice/**"};
+
+    return GroupedOpenApi
+        .builder()
+        .group("공지사항 API")
+        .pathsToMatch(paths)
+        .addOpenApiCustomiser(buildSecurityOpenApi()).build();
+  }
+
+  @Bean
   public GroupedOpenApi s3Api() {
     String[] paths = {"/s3/**"};
 

--- a/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
+++ b/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
@@ -48,7 +48,10 @@ public enum ErrorCode {
 
   // S3
   S3_SERVICE_ERROR(500, "S3001", "AmazonServiceException 에러가 발생하였습니다."),
-  S3_SDK_ERROR(500, "S3002", "SdkClientException 에러가 발생하였습니다.");
+  S3_SDK_ERROR(500, "S3002", "SdkClientException 에러가 발생하였습니다."),
+
+  // Notice
+  NOTICE_NOT_FOUND(404, "N001", "공지사항이 존재하지 않습니다.");
 
   private final String code;
   private final String message;

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -83,10 +83,10 @@ class ExhibitServiceTest {
   @Test
   public void getExhibitCount_전시의_개수를_반환한다() throws Exception {
     User user = createUser("user", "tu1");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     for (int i = 0; i < 5; i++) {
       CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-          defaultCateogry.getId(),
+          defaultCategory.getId(),
           LocalDate.now());
       Long created = exhibitService.create(exhibitRequestDto, user.getId());
       exhibitService.publish(created,user.getId());
@@ -98,9 +98,9 @@ class ExhibitServiceTest {
   @Test
   public void create_전시를_생성한다() throws Exception {
     User user = createUser("user", "tu1");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-        defaultCateogry.getId(),
+        defaultCategory.getId(),
         LocalDate.now());
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
@@ -113,9 +113,9 @@ class ExhibitServiceTest {
   public void create_다른_사용자의_카테고리에_전시를_생성하려고_하는_경우_예외를_발생한다() throws Exception {
     User user = createUser("user", "tu");
     User userAnother = createUser("userAnother", "tu2");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-        defaultCateogry.getId(),
+        defaultCategory.getId(),
         LocalDate.now());
 
     assertThatThrownBy(() -> {
@@ -126,9 +126,9 @@ class ExhibitServiceTest {
   @Test
   public void publish_임시저장된_전시를_영구저장한다() throws Exception {
     User user = createUser("user", "tu");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-        defaultCateogry.getId(),
+        defaultCategory.getId(),
         LocalDate.now());
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
@@ -141,9 +141,9 @@ class ExhibitServiceTest {
   @Test
   public void publish_이미_발행된_전시를_영구_저장_요청하면_예외를_발생한다() throws Exception {
     User user = createUser("user", "tu");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-        defaultCateogry.getId(),
+        defaultCategory.getId(),
         LocalDate.now());
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
@@ -158,9 +158,9 @@ class ExhibitServiceTest {
   @Test
   public void update_전시를_수정한다() throws Exception {
     User user = createUser("user", "tu");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-        defaultCateogry.getId(),
+        defaultCategory.getId(),
         LocalDate.now());
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());
@@ -168,7 +168,7 @@ class ExhibitServiceTest {
 
     String updatedName = "rename";
     exhibitService.update(
-        new UpdateExhibitRequestDto(updatedName, LocalDate.now(), defaultCateogry.getId()),
+        new UpdateExhibitRequestDto(updatedName, LocalDate.now(), defaultCategory.getId()),
         exhibit.getId(),
         user.getId());
 
@@ -180,9 +180,9 @@ class ExhibitServiceTest {
   @Test
   public void delete_전시를_삭제한다() throws Exception {
     User user = createUser("user", "tu");
-    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
-        defaultCateogry.getId(),
+        defaultCategory.getId(),
         LocalDate.now());
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -81,6 +81,21 @@ class ExhibitServiceTest {
   }
 
   @Test
+  public void getExhibitCount_전시의_개수를_반환한다() throws Exception {
+    User user = createUser("user", "tu1");
+    CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);
+    for (int i = 0; i < 5; i++) {
+      CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
+          defaultCateogry.getId(),
+          LocalDate.now());
+      Long created = exhibitService.create(exhibitRequestDto, user.getId());
+      exhibitService.publish(created,user.getId());
+    }
+    int exhibitCount = exhibitService.getExhibitCount(user.getId());
+    assertThat(exhibitCount).isEqualTo(5);
+  }
+
+  @Test
   public void create_전시를_생성한다() throws Exception {
     User user = createUser("user", "tu1");
     CategoryDto defaultCateogry = categoryService.categoriesOf(user.getId()).get(0);

--- a/src/test/java/com/yapp/artie/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/notice/service/NoticeServiceTest.java
@@ -2,10 +2,12 @@ package com.yapp.artie.domain.notice.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yapp.artie.domain.notice.domain.Notice;
 import com.yapp.artie.domain.notice.dto.NoticeDetailInfo;
 import com.yapp.artie.domain.notice.dto.NoticeDto;
+import com.yapp.artie.domain.notice.exception.NoticeNotFoundException;
 import java.util.List;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
@@ -34,11 +36,21 @@ class NoticeServiceTest {
   }
 
   @Test
-  public void notices_공지사항_상세를_조회한다() throws Exception {
+  public void notice_공지사항_상세를_조회한다() throws Exception {
     String expectedContents = "sample data";
     Notice notice = Notice.create("test1", expectedContents);
     em.persist(notice);
     NoticeDetailInfo detail = noticeService.notice(notice.getId());
     assertThat(detail.getContents()).isEqualTo(expectedContents);
+  }
+
+  @Test
+  public void notice_존재하지_않는_공지사항을_조회_시도할_경우_예외를_발생() throws Exception {
+    String expectedContents = "sample data";
+    Notice notice = Notice.create("test1", expectedContents);
+    em.persist(notice);
+    assertThatThrownBy(() -> {
+      noticeService.notice(22L);
+    }).isInstanceOf(NoticeNotFoundException.class);
   }
 }

--- a/src/test/java/com/yapp/artie/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/notice/service/NoticeServiceTest.java
@@ -4,6 +4,7 @@ package com.yapp.artie.domain.notice.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.yapp.artie.domain.notice.domain.Notice;
+import com.yapp.artie.domain.notice.dto.NoticeDetailInfo;
 import com.yapp.artie.domain.notice.dto.NoticeDto;
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -30,5 +31,14 @@ class NoticeServiceTest {
     }
     List<NoticeDto> notices = noticeService.notices();
     assertThat(notices.size()).isEqualTo(4);
+  }
+
+  @Test
+  public void notices_공지사항_상세를_조회한다() throws Exception {
+    String expectedContents = "sample data";
+    Notice notice = Notice.create("test1", expectedContents);
+    em.persist(notice);
+    NoticeDetailInfo detail = noticeService.notice(notice.getId());
+    assertThat(detail.getContents()).isEqualTo(expectedContents);
   }
 }

--- a/src/test/java/com/yapp/artie/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/notice/service/NoticeServiceTest.java
@@ -1,0 +1,34 @@
+package com.yapp.artie.domain.notice.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yapp.artie.domain.notice.domain.Notice;
+import com.yapp.artie.domain.notice.dto.NoticeDto;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class NoticeServiceTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  NoticeService noticeService;
+
+  @Test
+  public void notices_공지사항_목록을_조회한다() throws Exception {
+    for (int i = 0; i < 4; i++) {
+      Notice notice = Notice.create("test " + i, "sample data");
+      em.persist(notice);
+    }
+    List<NoticeDto> notices = noticeService.notices();
+    assertThat(notices.size()).isEqualTo(4);
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/user/service/UserThumbnailServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/service/UserThumbnailServiceTest.java
@@ -1,0 +1,68 @@
+package com.yapp.artie.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yapp.artie.domain.archive.dto.cateogry.CategoryDto;
+import com.yapp.artie.domain.archive.dto.cateogry.CreateCategoryRequestDto;
+import com.yapp.artie.domain.archive.dto.exhibit.CreateExhibitRequestDto;
+import com.yapp.artie.domain.archive.service.CategoryService;
+import com.yapp.artie.domain.archive.service.ExhibitService;
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.dto.response.UserThumbnailResponseDto;
+import java.time.LocalDate;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class UserThumbnailServiceTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  ExhibitService exhibitService;
+
+  @Autowired
+  CategoryService categoryService;
+
+  @Autowired
+  UserThumbnailService userThumbnailService;
+
+  User createUser(String name, String uid) {
+    User user = new User();
+    user.setName(name);
+    user.setUid(uid);
+    em.persist(user);
+    categoryService.create(new CreateCategoryRequestDto("test"), user.getId());
+
+    return user;
+  }
+
+  void createExhibit(User user) {
+    CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
+    CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
+        defaultCategory.getId(),
+        LocalDate.now());
+
+    Long created = exhibitService.create(exhibitRequestDto, user.getId());
+    exhibitService.publish(created, user.getId());
+  }
+
+  @Test
+  public void getUserThumbnail_사용자의_닉네임과_전시개수를_반환한다() throws Exception {
+    String expectedName = "le2sky";
+    int expectedCount = 10;
+    User user = createUser(expectedName, "test-123");
+    for (int i = 0; i < expectedCount; i++) {
+      createExhibit(user);
+    }
+
+    UserThumbnailResponseDto userThumbnail = userThumbnailService.getUserThumbnail(user.getId());
+    assertThat(userThumbnail.getExhibitCount()).isEqualTo(10);
+    assertThat(userThumbnail.getName()).isEqualTo(expectedName);
+  }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

마이페이지에 사용자의 썸네일 조회 기능과 공지사항 조회 기능을 구현했습니다. 참고로 공지사항 생성 로직은 제외했습니다.

## 관련 이슈

close #36 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




