### PR TITLE
전시 정보에 링크 정보 반영

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
@@ -105,9 +105,9 @@ public class Exhibit extends BaseEntity {
     return new Exhibit(user, category, contents, publication);
   }
 
-  public void update(String name, LocalDate postDate, Category category) {
+  public void update(String name, LocalDate postDate, String attachedLink, Category category) {
     this.contents = new ExhibitContents(name, contents().getReview(),
-        contents().getAttachedLink(), postDate);
+        attachedLink, postDate);
     categorize(category);
   }
 

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
@@ -98,8 +98,9 @@ public class Exhibit extends BaseEntity {
     artwork.display(this);
   }
 
-  public static Exhibit create(String name, LocalDate postDate, Category category, User user) {
-    ExhibitContents contents = new ExhibitContents(name, null, null, postDate);
+  public static Exhibit create(String name, LocalDate postDate, Category category, User user,
+      String attachedLink) {
+    ExhibitContents contents = new ExhibitContents(name, null, attachedLink, postDate);
     Publication publication = new Publication();
     return new Exhibit(user, category, contents, publication);
   }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CreateExhibitRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CreateExhibitRequestDto.java
@@ -20,9 +20,14 @@ public class CreateExhibitRequestDto {
   @Schema(description = "관람 날짜")
   private LocalDate postDate;
 
-  public CreateExhibitRequestDto(String name, Long categoryId, LocalDate postDate) {
+  @Schema(description = "전시 링크", nullable = true)
+  private String attachedLink;
+
+  public CreateExhibitRequestDto(String name, Long categoryId, LocalDate postDate,
+      String attachedLink) {
     this.name = name;
     this.categoryId = categoryId;
     this.postDate = postDate;
+    this.attachedLink = attachedLink;
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfo.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfo.java
@@ -39,10 +39,13 @@ public class PostDetailInfo {
   @Schema(description = "대표 이미지")
   private String mainImage;
 
+  @Schema(description = "전시 링크")
+  private String attachedLink;
+
   @Builder
   public PostDetailInfo(@NonNull Long id, @NonNull String name, @NonNull LocalDate postDate,
       boolean isPublished, @NonNull Long categoryId, @NonNull String categoryName,
-      String mainImage) {
+      String mainImage, String attachedLink) {
     this.id = id;
     this.name = name;
     this.postDate = postDate;
@@ -50,5 +53,6 @@ public class PostDetailInfo {
     this.categoryId = categoryId;
     this.categoryName = categoryName;
     this.mainImage = mainImage;
+    this.attachedLink = attachedLink;
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostInfoDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostInfoDto.java
@@ -20,6 +20,9 @@ public class PostInfoDto {
   @Schema(description = "관람 날짜")
   private final LocalDate postDate;
 
+  @Schema(description = "전시 링크")
+  private final String attachedLink;
+
   @Schema(description = "임시 저장 여부")
   private final boolean isPublished;
 }

--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/UpdateExhibitRequestDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/UpdateExhibitRequestDto.java
@@ -17,12 +17,17 @@ public class UpdateExhibitRequestDto {
   @Schema(description = "수정할 날짜")
   private LocalDate postDate;
 
-  @Schema(description = "변경할 카테고리 ID")
+  @Schema(description = "수정할 카테고리 ID")
   private Long categoryId;
 
-  public UpdateExhibitRequestDto(String name, LocalDate postDate, Long categoryId) {
+  @Schema(description = "수정할 전시 링크")
+  private String attachedLink;
+
+  public UpdateExhibitRequestDto(String name, LocalDate postDate, Long categoryId,
+      String attachedLink) {
     this.name = name;
     this.postDate = postDate;
     this.categoryId = categoryId;
+    this.attachedLink = attachedLink;
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -34,7 +34,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   Optional<Exhibit> findDetailExhibitEntityGraphById(Long id);
 
   @Query("select new com.yapp.artie.domain.archive.dto.exhibit."
-      + "PostInfoDto(e.id, e.contents.name, e.contents.date, e.publication.isPublished) "
+      + "PostInfoDto(e.id, e.contents.name, e.contents.date, e.contents.attachedLink, e.publication.isPublished) "
       + "from Exhibit e where e.user = :user and e.publication.isPublished = false")
   List<PostInfoDto> findDraftExhibitDto(@Param("user") User user);
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -137,7 +137,7 @@ public class ExhibitService {
     Category category = categoryService.findCategoryWithUser(
         createExhibitRequestDto.getCategoryId(), userId);
     Exhibit exhibit = Exhibit.create(createExhibitRequestDto.getName(),
-        createExhibitRequestDto.getPostDate(), category, findUser(userId));
+        createExhibitRequestDto.getPostDate(), category, findUser(userId), null);
 
     return exhibitRepository.save(exhibit)
         .getId();

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -162,7 +162,7 @@ public class ExhibitService {
         updateExhibitRequestDto.getCategoryId(), userId);
 
     exhibit.update(updateExhibitRequestDto.getName(), updateExhibitRequestDto.getPostDate(),
-        category);
+        updateExhibitRequestDto.getAttachedLink(), category);
   }
 
   @Transactional

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -225,6 +225,7 @@ public class ExhibitService {
         .categoryId(exhibit.getCategory().getId())
         .categoryName(exhibit.getCategory().getName())
         .mainImage(imageUri)
+        .attachedLink(exhibit.contents().getAttachedLink())
         .build();
   }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -137,7 +137,8 @@ public class ExhibitService {
     Category category = categoryService.findCategoryWithUser(
         createExhibitRequestDto.getCategoryId(), userId);
     Exhibit exhibit = Exhibit.create(createExhibitRequestDto.getName(),
-        createExhibitRequestDto.getPostDate(), category, findUser(userId), null);
+        createExhibitRequestDto.getPostDate(), category, findUser(userId),
+        createExhibitRequestDto.getAttachedLink());
 
     return exhibitRepository.save(exhibit)
         .getId();
@@ -194,6 +195,7 @@ public class ExhibitService {
     return artworkRepository.findMainArtworkByExhibitId(exhibit)
         .map(artwork -> s3Utils.getFullUri(artwork.getContents().getUri())).orElse(null);
   }
+
   // TODO : public이 아니도록 수정
   public void validateOwnedByUser(User user, Exhibit exhibit) {
     if (!exhibit.ownedBy(user)) {

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -213,7 +213,7 @@ public class ExhibitService {
 
   private PostInfoDto buildExhibitionInformation(Exhibit exhibit) {
     return new PostInfoDto(exhibit.getId(), exhibit.contents().getName(),
-        exhibit.contents().getDate(), exhibit.isPublished());
+        exhibit.contents().getDate(), exhibit.contents().getAttachedLink(), exhibit.isPublished());
   }
 
   private PostDetailInfo buildDetailExhibitionInformation(Exhibit exhibit, String imageUri) {

--- a/src/test/java/com/yapp/artie/domain/archive/service/ArtworkServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ArtworkServiceTest.java
@@ -61,7 +61,7 @@ class ArtworkServiceTest {
     User user = createUser("user", "tu");
     Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
     Exhibit exhibit = exhibitRepository.save(
-        Exhibit.create("test", LocalDate.now(), defaultCategory, user));
+        Exhibit.create("test", LocalDate.now(), defaultCategory, user, null));
     List<CreateArtworkTagDto> tags = new ArrayList<>();
     tags.add(new CreateArtworkTagDto(null, "sample-tag"));
 
@@ -85,7 +85,7 @@ class ArtworkServiceTest {
     User user = createUser("user", "tu");
     Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
     Exhibit exhibit = exhibitRepository.save(
-        Exhibit.create("test", LocalDate.now(), defaultCategory, user));
+        Exhibit.create("test", LocalDate.now(), defaultCategory, user, null));
     List<CreateArtworkTagDto> tags = new ArrayList<>();
     tags.add(new CreateArtworkTagDto(null, "sample-tag"));
 
@@ -113,7 +113,7 @@ class ArtworkServiceTest {
     User user = createUser("user", "tu");
     Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
     Exhibit exhibit = exhibitRepository.save(
-        Exhibit.create("test", LocalDate.now(), defaultCategory, user));
+        Exhibit.create("test", LocalDate.now(), defaultCategory, user, null));
     List<String> uriList = new ArrayList<>();
     uriList.add("sample-uri-1");
     uriList.add("sample-uri-2");

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -198,7 +198,7 @@ class ExhibitServiceTest {
     Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
 
     for (int i = 1; i <= 5; i++) {
-      Exhibit exhibit = Exhibit.create("test", LocalDate.now(), defaultCategory, user);
+      Exhibit exhibit = Exhibit.create("test", LocalDate.now(), defaultCategory, user, null);
       exhibitRepository.save(exhibit);
       exhibit.publish();
       LocalDateTime mockedCreatedAt = i < 5 ?
@@ -330,12 +330,12 @@ class ExhibitServiceTest {
         categoryService.categoriesOf(user.getId()).get(0).getId(), user.getId());
     Exhibit exhibit = exhibitRepository.save(
         Exhibit.create("test-0", LocalDate.now(), defaultCategory,
-            user));
+            user, null));
     exhibit.publish();
     for (int i = 1; i <= 10; i++) {
       exhibitRepository.save(
           Exhibit.create(String.format("test-%d", i), LocalDate.now(), defaultCategory,
-              user)).publish();
+              user, null)).publish();
     }
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), false, true);
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), true, true);
@@ -359,12 +359,12 @@ class ExhibitServiceTest {
         categoryService.categoriesOf(user.getId()).get(0).getId(), user.getId());
     Exhibit exhibit = exhibitRepository.save(
         Exhibit.create("test-0", LocalDate.now(), defaultCategory,
-            user));
+            user, null));
     exhibit.publish();
     for (int i = 1; i <= 10; i++) {
       exhibitRepository.save(
           Exhibit.create(String.format("test-%d", i), LocalDate.now(), defaultCategory,
-              user)).publish();
+              user, null)).publish();
     }
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), false, true);
     exhibitService.updatePostPinType(user.getId(), exhibit.getId(), true, true);
@@ -391,13 +391,13 @@ class ExhibitServiceTest {
 
     Exhibit exhibit = exhibitRepository.save(
         Exhibit.create(String.format("test-0"), LocalDate.now(), defaultCategory,
-            user));
+            user, null));
     exhibit.publish();
     artworkService.createBatch(imageUriList, exhibit.getId(), user.getId());
     for (int i = 1; i <= 10; i++) {
       Exhibit exhibitTest = exhibitRepository.save(
           Exhibit.create(String.format("test-%d", i), LocalDate.now(), defaultCategory,
-              user));
+              user, null));
       exhibitTest.publish();
       artworkService.createBatch(imageUriList, exhibitTest.getId(), user.getId());
     }
@@ -425,7 +425,8 @@ class ExhibitServiceTest {
 
     for (int i = 1; i <= 2; i++) {
       exhibitRepository.save(
-              Exhibit.create(String.format("test-%d", i), LocalDate.now(), defaultCategory, user))
+              Exhibit.create(String.format("test-%d", i), LocalDate.now(), defaultCategory, user,
+                  null))
           .publish();
     }
 

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -89,7 +89,7 @@ class ExhibitServiceTest {
           defaultCategory.getId(),
           LocalDate.now(), null);
       Long created = exhibitService.create(exhibitRequestDto, user.getId());
-      exhibitService.publish(created,user.getId());
+      exhibitService.publish(created, user.getId());
     }
     int exhibitCount = exhibitService.getExhibitCount(user.getId());
     assertThat(exhibitCount).isEqualTo(5);
@@ -167,14 +167,17 @@ class ExhibitServiceTest {
     Exhibit exhibit = em.find(Exhibit.class, created);
 
     String updatedName = "rename";
+    String updatedLink = "www.artie.com";
     exhibitService.update(
-        new UpdateExhibitRequestDto(updatedName, LocalDate.now(), defaultCategory.getId()),
+        new UpdateExhibitRequestDto(updatedName, LocalDate.now(), defaultCategory.getId(),
+            updatedLink),
         exhibit.getId(),
         user.getId());
 
     PostInfoDto actual = exhibitService.getExhibitInformation(exhibit.getId(),
         user.getId());
     assertThat(actual.getName()).isEqualTo(updatedName);
+    assertThat(actual.getAttachedLink()).isEqualTo(updatedLink);
   }
 
   @Test

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -87,7 +87,7 @@ class ExhibitServiceTest {
     for (int i = 0; i < 5; i++) {
       CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
           defaultCategory.getId(),
-          LocalDate.now());
+          LocalDate.now(), null);
       Long created = exhibitService.create(exhibitRequestDto, user.getId());
       exhibitService.publish(created,user.getId());
     }
@@ -101,7 +101,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     Optional<Exhibit> exhibit = Optional.ofNullable(em.find(Exhibit.class, created));
@@ -116,7 +116,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
 
     assertThatThrownBy(() -> {
       exhibitService.create(exhibitRequestDto, userAnother.getId());
@@ -129,7 +129,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());
@@ -144,7 +144,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());
@@ -161,7 +161,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());
     Exhibit exhibit = em.find(Exhibit.class, created);
@@ -183,7 +183,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());
 
@@ -229,7 +229,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long exhibitId1 = exhibitService.create(exhibitRequestDto, user.getId());
     Long exhibitId2 = exhibitService.create(exhibitRequestDto, user.getId());
 
@@ -250,7 +250,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long exhibitId1 = exhibitService.create(exhibitRequestDto, user.getId());
     Long exhibitId2 = exhibitService.create(exhibitRequestDto, user.getId());
 
@@ -272,7 +272,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long exhibitId1 = exhibitService.create(exhibitRequestDto, user.getId());
     Long exhibitId2 = exhibitService.create(exhibitRequestDto, user.getId());
 
@@ -294,7 +294,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long exhibitId1 = exhibitService.create(exhibitRequestDto, user.getId());
 
     exhibitService.updatePostPinType(user.getId(), exhibitId1, true, true);
@@ -311,7 +311,7 @@ class ExhibitServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
     Long exhibitId1 = exhibitService.create(exhibitRequestDto, user.getId());
 
     exhibitService.updatePostPinType(user.getId(), exhibitId1, true, true);

--- a/src/test/java/com/yapp/artie/domain/user/service/UserThumbnailServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/service/UserThumbnailServiceTest.java
@@ -46,7 +46,7 @@ class UserThumbnailServiceTest {
     CategoryDto defaultCategory = categoryService.categoriesOf(user.getId()).get(0);
     CreateExhibitRequestDto exhibitRequestDto = new CreateExhibitRequestDto("test",
         defaultCategory.getId(),
-        LocalDate.now());
+        LocalDate.now(), null);
 
     Long created = exhibitService.create(exhibitRequestDto, user.getId());
     exhibitService.publish(created, user.getId());


### PR DESCRIPTION
# 구현 내용

## 구현 요약

전시 생성, 수정, 조회 로직에서 `전시 링크(attachedLink)`가  반환, 사용할 수 있도록 변경했습니다.
피그마 화면에서는 보이지 않지만, 윤선님에게 물어봤는데 전시 링크도 수정 가능하다고 해서 업데이트 로직에도 반영했습니다.



## 관련 이슈

#78 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)




