### PR TITLE
마지막 작품 삭제시 해당하는 전시까지 삭제하는 로직 추가

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
@@ -1,7 +1,11 @@
 package com.yapp.artie.domain.archive.domain.artwork;
 
 import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.domain.tag.Tag;
 import com.yapp.artie.global.common.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -11,6 +15,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -37,6 +42,9 @@ public class Artwork extends BaseEntity {
 
   @Embedded
   private ArtworkContents contents;
+
+  @OneToMany(mappedBy = "artwork", cascade = CascadeType.REMOVE)
+  List<Tag> tags = new ArrayList<>();
 
   public Artwork(Exhibit exhibit, boolean isMain, ArtworkContents contents) {
     this.exhibit = exhibit;

--- a/src/main/java/com/yapp/artie/domain/archive/repository/TagRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/TagRepository.java
@@ -12,5 +12,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
   List<Tag> findAllByArtworkOrderBySequenceAsc(Artwork artwork);
 
   List<Tag> findAllByArtwork(Artwork artwork);
+
+  List<Tag> findAllByName(String name);
 }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -99,9 +99,14 @@ public class ArtworkService {
   @Transactional
   public void delete(Long id, Long userId) {
     Artwork artwork = findById(id, userId);
-    tagService.deleteAllByArtwork(artwork);
     String imageUri = artwork.getContents().getUri();
-    artworkRepository.delete(artwork);
+
+    Long artworkNum = artworkRepository.countArtworkByExhibitId(artwork.getExhibit().getId());
+    if (artworkNum <= 1) {
+      exhibitService.delete(artwork.getExhibit().getId(), userId);
+    } else {
+      artworkRepository.delete(artwork);
+    }
     s3Service.deleteObject(imageUri);
   }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [DELETE] /artwork/{id} 작품 삭제 API : 마지막 작품 삭제시 해당하는 전시까지 삭제하는 로직 추가
- 전시 삭제 메소드 ( ExhibitService.delete ) 의 소속된 작품, 태그까지 삭제하는지 확인하는 테스트 로직 추가

## 관련 이슈

close #81 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




