### PR TITLE
닉네임 변경 API 추가 / 카테고리 목록 조회시 해당 카테고리의 전시 수 필드 반환

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/dto/cateogry/CategoryDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/cateogry/CategoryDto.java
@@ -19,9 +19,20 @@ public class CategoryDto {
   @Schema(description = "카테고리 순서")
   private int sequence;
 
+  @Schema(description = "카테고리 별 전시수")
+  private int postNum;
+
   public CategoryDto(Long id, String name, int sequence) {
     this.id = id;
     this.name = name;
     this.sequence = sequence;
+    this.postNum = 0;
+  }
+
+  public CategoryDto(Long id, String name, int sequence, int postNum) {
+    this.id = id;
+    this.name = name;
+    this.sequence = sequence;
+    this.postNum = postNum;
   }
 }

--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -84,4 +84,9 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
   List<ExhibitByDateResponseDto> findExhibitsByDate(@Param("user") User user,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+  @Query("select count(e.id) from Exhibit e "
+      + "where e.category = :category "
+      + "and e.publication.isPublished = true")
+  int countExhibitByCategory(@Param("category") Category category);
 }

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -28,6 +28,11 @@ public class UserService implements UserDetailsService {
     return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
   }
 
+  public void updateUserName(Long userId, String name) {
+    User user = findById(userId);
+    user.setName(name);
+  }
+
   @Transactional
   public CreateUserResponseDto register(String uid, String username, String picture) {
     User user = findByUid(uid)

--- a/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
@@ -1,0 +1,34 @@
+package com.yapp.artie.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.repository.UserRepository;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class UserServiceTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  UserService userService;
+
+  @Test
+  public void updateUserName() throws Exception {
+    User user = userRepository.save(User.create("sample-uid", "sample-name", "sample-picture"));
+
+    userService.updateUserName(user.getId(), "sample-name-2");
+
+    assertThat(em.find(User.class, user.getId()).getName()).isEqualTo("sample-name-2");
+  }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [PATCH] /user/{id} 닉네임 변경 API 
  - API 추가
- [GET] /category 카테고리 목록 조회 API
  - 해당 카테고리의 전시 수 필드 반환하도록 로직 및 필드 추가

## 관련 이슈

close #102

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




