### PR TITLE
유저 닉네임 변경 API 쿼리 변수 어노테이션 버그 개선

### DIFF
--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -113,7 +113,7 @@ public class UserController {
   @PatchMapping("/{id}")
   public ResponseEntity<? extends HttpEntity> updateUserName(Authentication authentication,
       @Parameter(name = "id", description = "유저 ID", in = ParameterIn.PATH) @Valid @PathVariable("id") Long artworkId,
-      @Parameter(name = "name", description = "변경할 닉네임", in = ParameterIn.QUERY) @Valid @PathVariable("name") String name) {
+      @Parameter(name = "name", description = "변경할 닉네임", in = ParameterIn.QUERY) @Valid @RequestParam("name") String name) {
 
     Long userId = getUserId(authentication);
     userService.updateUserName(userId, name);

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -28,11 +28,6 @@ public class UserService implements UserDetailsService {
     return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
   }
 
-  public void updateUserName(Long userId, String name) {
-    User user = findById(userId);
-    user.setName(name);
-  }
-
   @Transactional
   public CreateUserResponseDto register(String uid, String username, String picture) {
     User user = findByUid(uid)
@@ -55,5 +50,11 @@ public class UserService implements UserDetailsService {
         .password(user.getUid())
         .authorities("user")
         .build();
+  }
+  
+  @Transactional
+  public void updateUserName(Long userId, String name) {
+    User user = findById(userId);
+    user.setName(name);
   }
 }

--- a/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
@@ -24,7 +24,7 @@ class UserServiceTest {
   UserService userService;
 
   @Test
-  public void updateUserName() throws Exception {
+  public void updateUserName() {
     User user = userRepository.save(User.create("sample-uid", "sample-name", "sample-picture"));
 
     userService.updateUserName(user.getId(), "sample-name-2");


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 유저 닉네임 변경 API에서 쿼리 변수 name을 내부적으로 path variable로 처리하려고 하여 발생하는 에러를 개선하였습니다.

## 관련 이슈

close #102 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




