### PR TITLE
회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -24,6 +24,7 @@ import org.apache.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -75,6 +76,21 @@ public class UserController {
     User user = userService.findById(userId);
 
     return ResponseEntity.ok().body(user);
+  }
+
+  @Operation(summary = "유저 삭제", description = "회원 탈퇴")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204",
+          description = "유저가 성공적으로 삭제됨",
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseEntity.class))),
+  })
+  @DeleteMapping("/")
+  public ResponseEntity<? extends HttpEntity> deleteUser(Authentication authentication) {
+    // Long userId = Long.parseLong(authentication.getName());
+    Long userId = 1L;
+    userService.delete(userId);
+    return ResponseEntity.noContent().build();
   }
 
   @Operation(summary = "마이페이지 썸네일 조회", description = "사용자 닉네임, 전시 개수 조회")

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -89,7 +89,7 @@ public class UserController {
   public ResponseEntity<? extends HttpEntity> deleteUser(Authentication authentication) {
     // Long userId = Long.parseLong(authentication.getName());
     Long userId = 1L;
-    userService.delete(userId);
+    userService.delete(userId, jwtService);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -40,6 +40,12 @@ public class UserService implements UserDetailsService {
     return new CreateUserResponseDto(user.getId());
   }
 
+  @Transactional
+  public void delete(Long id) {
+    User user = findById(id);
+    userRepository.deleteById(id);
+  }
+
   @Override
   public UserDetails loadUserByUsername(String username) {
     User user = userRepository.findByUid(username)

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import com.yapp.artie.domain.user.repository.UserRepository;
+import com.yapp.artie.global.authentication.JwtService;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -41,8 +42,9 @@ public class UserService implements UserDetailsService {
   }
 
   @Transactional
-  public void delete(Long id) {
+  public void delete(Long id, JwtService jwtService) {
     User user = findById(id);
+    jwtService.withdraw(user.getUid());
     userRepository.deleteById(id);
   }
 

--- a/src/main/java/com/yapp/artie/global/authentication/JwtDecoder.java
+++ b/src/main/java/com/yapp/artie/global/authentication/JwtDecoder.java
@@ -1,0 +1,44 @@
+package com.yapp.artie.global.authentication;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.yapp.artie.global.exception.authentication.ExpiredTokenException;
+import com.yapp.artie.global.exception.authentication.InvalidTokenException;
+import com.yapp.artie.global.exception.authentication.NotExistValidTokenException;
+import com.yapp.artie.global.exception.authentication.RevokedTokenException;
+import com.yapp.artie.global.exception.common.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtDecoder {
+
+  private final FirebaseAuth firebaseAuth;
+
+  public FirebaseToken decode(String token) {
+    try {
+      return firebaseAuth.verifyIdToken(token);
+    } catch (IllegalArgumentException e) {
+      // If the token is null, empty,
+      // or if the FirebaseApp instance does not have a project ID associated with it.
+      throw new NotExistValidTokenException();
+    } catch (FirebaseAuthException e) {
+      // If an error occurs while parsing or validating the token.
+      throw processAuthException(e);
+    }
+  }
+
+  private BusinessException processAuthException(FirebaseAuthException e) {
+    switch (e.getAuthErrorCode()) {
+      case EXPIRED_ID_TOKEN:
+        return new ExpiredTokenException();
+      case REVOKED_ID_TOKEN:
+        return new RevokedTokenException();
+      default:
+        return new InvalidTokenException();
+    }
+  }
+
+}

--- a/src/main/java/com/yapp/artie/global/authentication/JwtService.java
+++ b/src/main/java/com/yapp/artie/global/authentication/JwtService.java
@@ -1,65 +1,10 @@
 package com.yapp.artie.global.authentication;
 
-import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
-import com.yapp.artie.global.exception.authentication.ExpiredTokenException;
-import com.yapp.artie.global.exception.authentication.InvalidTokenException;
-import com.yapp.artie.global.exception.authentication.NotExistValidTokenException;
-import com.yapp.artie.global.exception.authentication.RevokedTokenException;
-import com.yapp.artie.global.exception.common.BusinessException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class JwtService {
+public interface JwtService {
 
-  private final FirebaseAuth firebaseAuth;
+  FirebaseToken verify(String header);
 
-  public FirebaseToken verify(String header) {
-    validateHeader(header);
-    return decode(refineHeaderAsToken(header));
-  }
-
-  private void validateHeader(String header) {
-    if (header == null || !header.startsWith("Bearer ") || header.trim().equals("Bearer")) {
-      throw new NotExistValidTokenException();
-    }
-  }
-
-  private FirebaseToken decode(String token) {
-    try {
-      return firebaseAuth.verifyIdToken(token);
-    } catch (IllegalArgumentException e) {
-      // If the token is null, empty,
-      // or if the FirebaseApp instance does not have a project ID associated with it.
-      throw new NotExistValidTokenException();
-    } catch (FirebaseAuthException e) {
-      // If an error occurs while parsing or validating the token.
-      throw processAuthException(e);
-    }
-  }
-
-  private BusinessException processAuthException(FirebaseAuthException e) {
-    switch (e.getAuthErrorCode()) {
-      case EXPIRED_ID_TOKEN:
-        return new ExpiredTokenException();
-      case REVOKED_ID_TOKEN:
-        return new RevokedTokenException();
-      default:
-        return new InvalidTokenException();
-    }
-  }
-
-  private String refineHeaderAsToken(String header) {
-    String authType = "Bearer";
-    if (header.startsWith(authType)) {
-      header = header.substring(authType.length()).trim();
-    }
-
-    return header;
-  }
+  void withdraw(String uid);
 }

--- a/src/main/java/com/yapp/artie/global/authentication/JwtServiceImpl.java
+++ b/src/main/java/com/yapp/artie/global/authentication/JwtServiceImpl.java
@@ -1,0 +1,42 @@
+package com.yapp.artie.global.authentication;
+
+import com.google.firebase.auth.FirebaseToken;
+import com.yapp.artie.global.exception.authentication.NotExistValidTokenException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtServiceImpl implements JwtService {
+
+  private final WithdrawalHandler withdrawalHandler;
+  private final JwtDecoder decoder;
+
+  @Override
+  public FirebaseToken verify(String header) {
+    validateHeader(header);
+    return decoder.decode(refineHeaderAsToken(header));
+  }
+
+  @Override
+  public void withdraw(String uid) {
+    withdrawalHandler.withdraw(uid);
+  }
+
+  private void validateHeader(String header) {
+    if (header == null || !header.startsWith("Bearer ") || header.trim().equals("Bearer")) {
+      throw new NotExistValidTokenException();
+    }
+  }
+
+  private String refineHeaderAsToken(String header) {
+    String authType = "Bearer";
+    if (header.startsWith(authType)) {
+      header = header.substring(authType.length()).trim();
+    }
+
+    return header;
+  }
+}

--- a/src/main/java/com/yapp/artie/global/authentication/WithdrawalHandler.java
+++ b/src/main/java/com/yapp/artie/global/authentication/WithdrawalHandler.java
@@ -1,0 +1,37 @@
+package com.yapp.artie.global.authentication;
+
+import com.google.firebase.auth.AuthErrorCode;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.yapp.artie.global.exception.authentication.FirebaseUserNotFoundException;
+import com.yapp.artie.global.exception.authentication.InvalidFirebaseUidException;
+import com.yapp.artie.global.exception.common.BusinessException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WithdrawalHandler {
+
+  private final FirebaseAuth firebaseAuth;
+
+  public void withdraw(String uid) {
+    try {
+      firebaseAuth.deleteUser(uid);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidFirebaseUidException();
+    } catch (FirebaseAuthException e) {
+      throw processWithDrawException(e);
+    }
+  }
+
+  private BusinessException processWithDrawException(FirebaseAuthException e) {
+    if (Objects.requireNonNull(e.getAuthErrorCode()) == AuthErrorCode.USER_NOT_FOUND) {
+      return new FirebaseUserNotFoundException();
+    }
+
+    return new InvalidFirebaseUidException();
+  }
+}
+

--- a/src/main/java/com/yapp/artie/global/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/artie/global/config/SecurityConfig.java
@@ -3,7 +3,7 @@ package com.yapp.artie.global.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.artie.global.authentication.JwtExceptionHandler;
 import com.yapp.artie.global.authentication.JwtFilter;
-import com.yapp.artie.global.authentication.JwtService;
+import com.yapp.artie.global.authentication.JwtServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -25,7 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   private final UserDetailsService userDetailsService;
-  private final JwtService jwtService;
+  private final JwtServiceImpl jwtService;
 
   @Override
   public void configure(HttpSecurity http) throws Exception {

--- a/src/main/java/com/yapp/artie/global/exception/authentication/FirebaseUserNotFoundException.java
+++ b/src/main/java/com/yapp/artie/global/exception/authentication/FirebaseUserNotFoundException.java
@@ -1,0 +1,12 @@
+package com.yapp.artie.global.exception.authentication;
+
+import com.yapp.artie.global.exception.common.BusinessException;
+import com.yapp.artie.global.exception.response.ErrorCode;
+
+public class FirebaseUserNotFoundException extends BusinessException {
+
+  public FirebaseUserNotFoundException() {
+    super(ErrorCode.FIREBASE_NOT_FOUND_USER);
+  }
+
+}

--- a/src/main/java/com/yapp/artie/global/exception/authentication/InvalidFirebaseUidException.java
+++ b/src/main/java/com/yapp/artie/global/exception/authentication/InvalidFirebaseUidException.java
@@ -1,0 +1,11 @@
+package com.yapp.artie.global.exception.authentication;
+
+import com.yapp.artie.global.exception.common.BusinessException;
+import com.yapp.artie.global.exception.response.ErrorCode;
+
+public class InvalidFirebaseUidException extends BusinessException {
+
+  public InvalidFirebaseUidException() {
+    super(ErrorCode.FIREBASE_INVALID_UID);
+  }
+}

--- a/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
+++ b/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
   FIREBASE_TOKEN_NOT_EXISTS(401, "F003", "유효한 토큰이 존재하지 않습니다."),
   FIREBASE_INVALID_TOKEN(401, "F004", "JWT 토큰 파싱에 실패했습니다."),
   FIREBASE_REVOKED_TOKEN(401, "F005", "취소된 토큰입니다."),
+  FIREBASE_NOT_FOUND_USER(404, "F006", "존재하지 않는 파이어베이스 사용자입니다."),
+  FIREBASE_INVALID_UID(401, "F007", "유요하지 않은 파이어베이스 식별자입니다."),
 
   // User
   USER_NOT_FOUND(404, "U001", "회원을 찾을 수 없습니다."),

--- a/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
@@ -1,9 +1,13 @@
 package com.yapp.artie.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.repository.UserRepository;
+
+import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
+import com.yapp.artie.domain.user.exception.UserNotFoundException;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,5 +34,15 @@ class UserServiceTest {
     userService.updateUserName(user.getId(), "sample-name-2");
 
     assertThat(em.find(User.class, user.getId()).getName()).isEqualTo("sample-name-2");
+  }
+
+  @Test
+  public void delete_사용자_삭제시_테이블에서_제거된다() throws Exception {
+    CreateUserResponseDto dto = userService.register("123", "le2sky", null);
+    userService.delete(dto.id);
+
+    assertThatThrownBy(() -> {
+      userService.delete(dto.id);
+    }).isInstanceOf(UserNotFoundException.class);
   }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [DELETE]  /user 토큰 기반 회원 탈퇴 API
    - API 추가 
    - Firebase 유저 삭제 기능 구현
    - **user 삭제시 전시, 카테고리, 태그 등 삭제 처리 하지 않음**
## 관련 이슈

#99

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




