### PR TITLE
작품 삭제 API의 대표 작품 삭제시 타 작품으로 설정되는 로직 추가

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/repository/ArtworkRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ArtworkRepository.java
@@ -29,9 +29,13 @@ public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
   )
   Page<Artwork> findAllArtworkAsPage(Pageable pageable, @Param("exhibit") Exhibit exhibit);
 
-  List<Artwork> findArtworksByExhibitOrderByCreatedAtDesc(Exhibit exhibit);
+  List<Artwork> findArtworksByExhibitOrderByCreatedAtDescIdDesc(Exhibit exhibit);
 
   @Modifying
   @Query("update Artwork a set a.isMain = false where a.exhibit = :exhibit")
   void updateArtworkNotMainByExhibit(@Param("exhibit") Exhibit exhibit);
+
+  @Query("select a from Artwork a where a.exhibit = :exhibit and a.id <> :deletedId order by a.createdAt, a.id")
+  List<Artwork> findFirstByExhibitWithoutDeleted(@Param("exhibit") Exhibit exhibit,
+      @Param("deletedId") Long deletedId);
 }

--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -54,7 +54,7 @@ public class ArtworkService {
 
   public List<ArtworkBrowseThumbnailDto> getArtworkBrowseThumbnail(Long exhibitId, Long userId) {
     Exhibit exhibit = exhibitService.getExhibitByUser(exhibitId, userId);
-    return artworkRepository.findArtworksByExhibitOrderByCreatedAtDesc(exhibit).stream()
+    return artworkRepository.findArtworksByExhibitOrderByCreatedAtDescIdDesc(exhibit).stream()
         .map(this::buildArtworkBrowseThumbnail).collect(Collectors.toList());
   }
 
@@ -106,6 +106,10 @@ public class ArtworkService {
       exhibitService.delete(artwork.getExhibit().getId(), userId);
     } else {
       artworkRepository.delete(artwork);
+      if (artwork.isMain()) {
+        artworkRepository.findFirstByExhibitWithoutDeleted(
+            artwork.getExhibit(), artwork.getId()).get(0).setMainArtwork();
+      }
     }
     s3Service.deleteObject(imageUri);
   }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [DELETE] /artwork/{id} 작품 삭제 API
  - 대표 작품 삭제시, 잔여 작품 중 가장 오래된 작품을 대표 작품으로 설정하는 로직 추가

## 관련 이슈

close #81 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




