### PR TITLE
유저 탈퇴시 정상적으로 데이터 삭제되지 않는 버그 개선 / 구조 개선 / 테스트 코드 추가 / 일부 authentication 처리 로직 개선

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
@@ -43,7 +43,7 @@ public class Artwork extends BaseEntity {
   @Embedded
   private ArtworkContents contents;
 
-  @OneToMany(mappedBy = "artwork", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "artwork", cascade = CascadeType.REMOVE)
   List<Tag> tags = new ArrayList<>();
 
   public Artwork(Exhibit exhibit, boolean isMain, ArtworkContents contents) {

--- a/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/artwork/Artwork.java
@@ -43,7 +43,7 @@ public class Artwork extends BaseEntity {
   @Embedded
   private ArtworkContents contents;
 
-  @OneToMany(mappedBy = "artwork", cascade = CascadeType.REMOVE)
+  @OneToMany(mappedBy = "artwork", cascade = CascadeType.ALL, orphanRemoval = true)
   List<Tag> tags = new ArrayList<>();
 
   public Artwork(Exhibit exhibit, boolean isMain, ArtworkContents contents) {

--- a/src/main/java/com/yapp/artie/domain/archive/domain/category/Category.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/category/Category.java
@@ -35,7 +35,7 @@ public class Category extends BaseEntity {
   @Column(nullable = false)
   private String name;
 
-  @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE)
   List<Exhibit> exhibits = new ArrayList<>();
 
   @Column(nullable = false, name = "seq")

--- a/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
+++ b/src/main/java/com/yapp/artie/domain/archive/domain/exhibit/Exhibit.java
@@ -44,7 +44,7 @@ public class Exhibit extends BaseEntity {
   @JoinColumn(name = "category_id", nullable = false)
   private Category category;
 
-  @OneToMany(mappedBy = "exhibit", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "exhibit", cascade = CascadeType.REMOVE)
   List<Artwork> artworks = new ArrayList<>();
 
   @Embedded

--- a/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
@@ -27,5 +27,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
   int countCategoriesByUser(@Param("user") User user);
 
   List<Category> findCategoriesByUserOrderBySequence(User user);
+
+  @Modifying(clearAutomatically = true)
+  void deleteAllByUser(User user);
 }
 

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -85,7 +85,7 @@ public class UserController {
           description = "유저가 성공적으로 삭제됨",
           content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseEntity.class))),
   })
-  @DeleteMapping("/")
+  @DeleteMapping()
   public ResponseEntity<? extends HttpEntity> deleteUser(Authentication authentication) {
     // Long userId = Long.parseLong(authentication.getName());
     Long userId = 1L;

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -71,8 +71,8 @@ public class UserController {
   })
   @GetMapping("/me")
   public ResponseEntity<User> me(Authentication authentication) {
-    // Long userId = Long.parseLong(authentication.getName());
-    Long userId = 1L;
+
+    Long userId = Long.parseLong(authentication.getName());
     User user = userService.findById(userId);
 
     return ResponseEntity.ok().body(user);

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -87,8 +87,8 @@ public class UserController {
   })
   @DeleteMapping()
   public ResponseEntity<? extends HttpEntity> deleteUser(Authentication authentication) {
-    // Long userId = Long.parseLong(authentication.getName());
-    Long userId = 1L;
+
+    Long userId = getUserId(authentication);
     userService.delete(userId);
     return ResponseEntity.noContent().build();
   }
@@ -102,8 +102,8 @@ public class UserController {
   })
   @GetMapping("/my-page")
   public ResponseEntity<UserThumbnailResponseDto> my(Authentication authentication) {
-    // Long userId = Long.parseLong(authentication.getName());
-    Long userId = 1L;
+
+    Long userId = getUserId(authentication);
     return ResponseEntity.ok().body(userThumbnailService.getUserThumbnail(userId));
   }
 

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -89,7 +89,7 @@ public class UserController {
   public ResponseEntity<? extends HttpEntity> deleteUser(Authentication authentication) {
     // Long userId = Long.parseLong(authentication.getName());
     Long userId = 1L;
-    userService.delete(userId, jwtService);
+    userService.delete(userId);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/yapp/artie/domain/user/domain/User.java
+++ b/src/main/java/com/yapp/artie/domain/user/domain/User.java
@@ -43,4 +43,13 @@ public class User extends BaseEntity {
     user.setProfileImage(picture);
     return user;
   }
+
+  public static User create(Long id, String uid, String name, String profileImage) {
+    User user = new User();
+    user.id = id;
+    user.uid = uid;
+    user.name = name;
+    user.profileImage = profileImage;
+    return user;
+  }
 }

--- a/src/main/java/com/yapp/artie/domain/user/domain/User.java
+++ b/src/main/java/com/yapp/artie/domain/user/domain/User.java
@@ -1,11 +1,16 @@
 package com.yapp.artie.domain.user.domain;
 
+import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.global.common.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,6 +32,9 @@ public class User extends BaseEntity {
   private String name;
 
   private String profileImage;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  List<Exhibit> categories = new ArrayList<>();
 
   public static User create(String uid, String name, String picture) {
     User user = new User();

--- a/src/main/java/com/yapp/artie/domain/user/domain/User.java
+++ b/src/main/java/com/yapp/artie/domain/user/domain/User.java
@@ -1,16 +1,11 @@
 package com.yapp.artie.domain.user.domain;
 
-import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.global.common.BaseEntity;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -32,9 +27,6 @@ public class User extends BaseEntity {
   private String name;
 
   private String profileImage;
-
-  @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
-  List<Exhibit> categories = new ArrayList<>();
 
   public static User create(String uid, String name, String picture) {
     User user = new User();

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService implements UserDetailsService {
 
   private final UserRepository userRepository;
+  private final JwtService jwtService;
 
   public Optional<User> findByUid(String uid) {
     return userRepository.findByUid(uid);
@@ -42,7 +43,7 @@ public class UserService implements UserDetailsService {
   }
 
   @Transactional
-  public void delete(Long id, JwtService jwtService) {
+  public void delete(Long id) {
     User user = findById(id);
     jwtService.withdraw(user.getUid());
     userRepository.deleteById(id);

--- a/src/main/java/com/yapp/artie/domain/user/service/UserService.java
+++ b/src/main/java/com/yapp/artie/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.yapp.artie.domain.user.service;
 
 import static org.springframework.security.core.userdetails.User.builder;
 
+import com.yapp.artie.domain.archive.repository.CategoryRepository;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService implements UserDetailsService {
 
   private final UserRepository userRepository;
+  private final CategoryRepository categoryRepository;
   private final JwtService jwtService;
 
   public Optional<User> findByUid(String uid) {
@@ -46,7 +48,9 @@ public class UserService implements UserDetailsService {
   public void delete(Long id) {
     User user = findById(id);
     jwtService.withdraw(user.getUid());
-    userRepository.deleteById(id);
+
+    categoryRepository.deleteAllByUser(user);
+    userRepository.delete(user);
   }
 
   @Override

--- a/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
+++ b/src/main/java/com/yapp/artie/global/exception/response/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
   FIREBASE_INVALID_TOKEN(401, "F004", "JWT 토큰 파싱에 실패했습니다."),
   FIREBASE_REVOKED_TOKEN(401, "F005", "취소된 토큰입니다."),
   FIREBASE_NOT_FOUND_USER(404, "F006", "존재하지 않는 파이어베이스 사용자입니다."),
-  FIREBASE_INVALID_UID(401, "F007", "유요하지 않은 파이어베이스 식별자입니다."),
+  FIREBASE_INVALID_UID(401, "F007", "유효하지 않은 파이어베이스 식별자입니다."),
 
   // User
   USER_NOT_FOUND(404, "U001", "회원을 찾을 수 없습니다."),

--- a/src/test/java/com/yapp/artie/BaseIntegrationTest.java
+++ b/src/test/java/com/yapp/artie/BaseIntegrationTest.java
@@ -1,0 +1,21 @@
+package com.yapp.artie;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Disabled
+@AutoConfigureMockMvc
+@Transactional
+public class BaseIntegrationTest {
+
+  @Autowired
+  protected MockMvc mvc;
+  @Autowired
+  protected ObjectMapper objectMapper;
+}

--- a/src/test/java/com/yapp/artie/domain/archive/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/repository/CategoryRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.yapp.artie.domain.archive.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yapp.artie.domain.archive.domain.artwork.Artwork;
+import com.yapp.artie.domain.archive.domain.category.Category;
+import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.domain.tag.Tag;
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.domain.UserTest;
+import com.yapp.artie.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class CategoryRepositoryTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  ExhibitRepository exhibitRepository;
+
+  @Autowired
+  ArtworkRepository artworkRepository;
+
+  @Autowired
+  TagRepository tagRepository;
+
+  @Test
+  @DisplayName("유저 기반 카테고리 삭제 - 카테고리가 삭제되면 해당하는 전시, 작품, 태그도 삭제되어야합니다")
+  void deleteAllByUser() {
+    User user = userRepository.save(UserTest.TEST_SAVED_USER);
+    Category category = categoryRepository.save(Category.create(user, "category-name", 1));
+    Exhibit exhibit = exhibitRepository.save(
+        Exhibit.create("exhibit-name", LocalDate.now(), category, user, "exhibit-link"));
+    Artwork artwork = artworkRepository.save(Artwork.create(exhibit, true, "artwork-uri"));
+    Tag tag = tagRepository.save(new Tag(user, artwork, 1, "tag-name"));
+    em.flush();
+    em.clear();
+
+    categoryRepository.deleteAllByUser(user);
+    em.flush();
+
+    assertThat(userRepository.findById(user.getId()).isPresent()).isTrue();
+    assertThat(categoryRepository.findById(category.getId()).isPresent()).isFalse();
+    assertThat(exhibitRepository.findById(exhibit.getId()).isPresent()).isFalse();
+    assertThat(artworkRepository.findById(artwork.getId()).isPresent()).isFalse();
+    assertThat(tagRepository.findById(tag.getId()).isPresent()).isFalse();
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,78 @@
+package com.yapp.artie.domain.user.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.yapp.artie.BaseIntegrationTest;
+import com.yapp.artie.domain.archive.domain.artwork.Artwork;
+import com.yapp.artie.domain.archive.domain.category.Category;
+import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
+import com.yapp.artie.domain.archive.domain.tag.Tag;
+import com.yapp.artie.domain.archive.repository.ArtworkRepository;
+import com.yapp.artie.domain.archive.repository.CategoryRepository;
+import com.yapp.artie.domain.archive.repository.ExhibitRepository;
+import com.yapp.artie.domain.archive.repository.TagRepository;
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.domain.UserTest;
+import com.yapp.artie.domain.user.repository.UserRepository;
+import com.yapp.artie.global.authentication.JwtServiceImpl;
+import java.time.LocalDate;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class UserControllerTest extends BaseIntegrationTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  ExhibitRepository exhibitRepository;
+
+  @Autowired
+  ArtworkRepository artworkRepository;
+
+  @Autowired
+  TagRepository tagRepository;
+
+  @MockBean
+  JwtServiceImpl jwtService;
+
+  // TODO : 헤더 토큰 ( Authentication ) 모킹 필요. 현재는 getUserId 메소드에 의존하고 있음
+  @Test
+  @DisplayName("유저 삭제(탈퇴) API - 유저 데이터가 삭제되면 해당 유저의 카테고리, 전시, 작품, 태그 데이터가 함께 삭제되어야합니다.")
+  public void deleteUser() throws Exception {
+    User user = userRepository.save(UserTest.TEST_SAVED_USER);
+    Category category = categoryRepository.save(Category.create(user, "category-name", 1));
+    Exhibit exhibit = exhibitRepository.save(
+        Exhibit.create("exhibit-name", LocalDate.now(), category, user, "exhibit-link"));
+    Artwork artwork = artworkRepository.save(Artwork.create(exhibit, true, "artwork-uri"));
+    Tag tag = tagRepository.save(new Tag(user, artwork, 1, "tag-name"));
+    em.clear();
+
+    doNothing().when(jwtService).withdraw(anyString());
+
+    mvc.perform(delete("/user"))
+        .andExpect(status().isNoContent())
+        .andDo(print());
+
+    em.flush();
+    assertThat(userRepository.findById(user.getId()).isPresent()).isFalse();
+    assertThat(categoryRepository.findById(category.getId()).isPresent()).isFalse();
+    assertThat(exhibitRepository.findById(exhibit.getId()).isPresent()).isFalse();
+    assertThat(artworkRepository.findById(artwork.getId()).isPresent()).isFalse();
+    assertThat(tagRepository.findById(tag.getId()).isPresent()).isFalse();
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/user/domain/UserTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/domain/UserTest.java
@@ -1,0 +1,11 @@
+package com.yapp.artie.domain.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("User 테스트")
+public class UserTest {
+
+  public static final User TEST_USER = User.create("test-uid", "test-name", "test-profile");
+  public static final User TEST_SAVED_USER = User.create(1L, "test-uid", "test-name",
+      "test-profile");
+}

--- a/src/test/java/com/yapp/artie/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,19 @@
+package com.yapp.artie.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.domain.UserTest;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class UserRepositoryTest {
+
+}

--- a/src/test/java/com/yapp/artie/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/repository/UserRepositoryTest.java
@@ -16,4 +16,22 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public class UserRepositoryTest {
 
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Test
+  @DisplayName("유저 삭제")
+  void delete() {
+    User user = userRepository.save(UserTest.TEST_SAVED_USER);
+    em.clear();
+
+    userRepository.delete(user);
+    em.flush();
+
+    assertThat(userRepository.findById(user.getId()).isPresent()).isFalse();
+  }
+
 }

--- a/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/service/UserServiceTest.java
@@ -1,99 +1,44 @@
 package com.yapp.artie.domain.user.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
-import com.yapp.artie.domain.archive.domain.artwork.Artwork;
-import com.yapp.artie.domain.archive.domain.category.Category;
-import com.yapp.artie.domain.archive.domain.exhibit.Exhibit;
 import com.yapp.artie.domain.user.domain.User;
-import com.yapp.artie.domain.user.repository.UserRepository;
-
-import com.yapp.artie.domain.user.dto.response.CreateUserResponseDto;
+import com.yapp.artie.domain.user.domain.UserTest;
 import com.yapp.artie.domain.user.exception.UserNotFoundException;
+import com.yapp.artie.domain.user.repository.UserRepository;
 import com.yapp.artie.global.authentication.JwtService;
-import io.opencensus.tags.Tag;
-import io.opencensus.tags.TagKey;
-import io.opencensus.tags.TagMetadata;
-import io.opencensus.tags.TagValue;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.BDDMockito;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
-  @Autowired
-  EntityManager em;
+  @InjectMocks
+  private UserService userService;
 
-  @Autowired
-  UserRepository userRepository;
+  @Mock
+  private UserRepository userRepository;
 
-  @Autowired
-  UserService userService;
-
-  JwtService mockJwtService = Mockito.mock(JwtService.class);
+  @Mock
+  private JwtService jwtService;
 
   @Test
-  public void updateUserName() {
-    User user = userRepository.save(User.create("sample-uid", "sample-name", "sample-picture"));
+  @DisplayName("유저 닉네임(이름) 변경 테스트 - 존재하지 않는 userId로 조회시 예외처리")
+  public void updateUserNameFailTest() throws Exception {
+    User user = UserTest.TEST_USER;
+    given(userRepository.findById(any())).willThrow(new UserNotFoundException());
 
-    userService.updateUserName(user.getId(), "sample-name-2");
-
-    assertThat(em.find(User.class, user.getId()).getName()).isEqualTo("sample-name-2");
+    assertThatThrownBy(() -> userService.updateUserName(user.getId(), "new-name")).isInstanceOf(
+        UserNotFoundException.class);
   }
 
-  @Test
-  public void delete_사용자_삭제시_테이블에서_제거된다() throws Exception {
-    CreateUserResponseDto dto = userService.register("123", "le2sky", null);
-    userService.delete(dto.id, mockJwtService);
-
-    assertThatThrownBy(() -> {
-      userService.delete(dto.id, mockJwtService);
-    }).isInstanceOf(UserNotFoundException.class);
-  }
-
-  @Test
-  public void delete_사용자_삭제시_파이어베이스에_사용자_삭제_요청() throws Exception {
-    String expectedUid = "123";
-    CreateUserResponseDto dto = userService.register(expectedUid, "le2sky", null);
-    userService.delete(dto.id, mockJwtService);
-
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    BDDMockito.then(mockJwtService)
-        .should()
-        .withdraw(captor.capture());
-
-    assertThat(captor.getValue()).isEqualTo(expectedUid);
-  }
-
-
-  @Test
-  public void delete_사용자_삭제시_모든_데이터가_삭제된다() throws Exception {
-    CreateUserResponseDto dto = userService.register("uid", "le2sky", null);
-    User user = userService.findById(dto.id);
-    Category category = Category.create(user, "temp", 1);
-    Exhibit exhibit = Exhibit.create("temp", LocalDate.now(), category, user, null);
-    Artwork artwork = Artwork.create(exhibit, true, "name", "artist", "uri");
-
-    em.persist(category);
-    em.persist(exhibit);
-    em.persist(artwork);
-
-    userService.delete(dto.id, mockJwtService);
-
-    em.flush();
-    em.clear();
-    assertThat(em.find(Category.class, category.getId())).isNull();
-    assertThat(em.find(Exhibit.class, exhibit.getId())).isNull();
-    assertThat(em.find(Artwork.class, artwork.getId())).isNull();
-  }
+  // TODO: delete 서비스 메소드가, jwtService.withDraw를, FirebaseAuth.deleteUser를 잘 호출하는지 확인하는 테스트 추가 필요
 }


### PR DESCRIPTION
# 구현 내용

## API 수정
- [DELETE] /user 유저 탈퇴 API : 버그 수정
  - URI의 오타 수정 ( /user/ -> /user )
  - jwtService를 UserService.delete 메소드의 파라미터로 받지 않도록 개선
  - User 엔티티는 다른 엔티티와의 개인 소유 관계가 아니기 때문에, cascade 삭제가 부적합한 것으로 보여, 수동적으로 삭제하도록 개선
  - 해당 유저의 카테고리 데이터를 먼저 삭제하고, 카테고리 삭제시 cascade 삭제로 전시, 작품, 태그가 삭제되도록 함
  - 카테고리 데이터가 삭제된 이후, 유저 데이터를 삭제함
- 유저 API의 런칭 목적 authentication 처리 로직 교체
  - 기존에는 개발상 편의를 위해 단순히 1L으로 처리하였음
  - 런칭을 위해, 테스트 계정이 아닌 요청은 정상적으로 처리하도록 메소드 적용하여 처리

## 테스트
- 통합 테스트 base class 추가
- 테스트 상 편의를 위해, User 엔티티의 id를 입력하는 생성자 추가
- 테스트 상 편의를 위해, 테스트용 유저 정적 변수 선언
- Category Repository Unit Test 추가
- 유저 기반 카테고리를 삭제하는 CategoryRepository.deleteAllByUser메소드를 검증하는 레포지토리 테스트 추가
- 카테고리를 삭제하면 전시데이터도 삭제되는지에 대해, CategoryService.delete 메소드를 검증하는 테스트 추가


- 기존의 User Service Test를 단위 테스트로 처리하도록 변경
- UserService.updateUserName 메소드의 서비스 단위 테스트 추가
- 유저 삭제 API의 통합 테스트 추가
- UserRepository의 단위 테스트 추가
- UserRepository.delete를 검증하는 레포지토리 단위 테스트 추가

## 기타
- 일부 예외의 메세지 오타 수정

## 관련 이슈

close #108
references with #86

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




