### PR TITLE
PostDetailInfo에 isPinned 필드 추가

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfo.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/PostDetailInfo.java
@@ -42,10 +42,13 @@ public class PostDetailInfo {
   @Schema(description = "전시 링크")
   private String attachedLink;
 
+  @Schema(description = "고정 여부")
+  private boolean isPinned;
+
   @Builder
   public PostDetailInfo(@NonNull Long id, @NonNull String name, @NonNull LocalDate postDate,
       boolean isPublished, @NonNull Long categoryId, @NonNull String categoryName,
-      String mainImage, String attachedLink) {
+      String mainImage, String attachedLink, boolean isPinned) {
     this.id = id;
     this.name = name;
     this.postDate = postDate;
@@ -54,5 +57,6 @@ public class PostDetailInfo {
     this.categoryName = categoryName;
     this.mainImage = mainImage;
     this.attachedLink = attachedLink;
+    this.isPinned = isPinned;
   }
 }

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -365,6 +365,8 @@ class ExhibitServiceTest {
     assertThat(results.getNumber()).isEqualTo(0);
     assertThat(results.getContent().get(0).getId()).isEqualTo(exhibit.getId());
     assertThat(results.getContent().get(0).getName()).isEqualTo(exhibit.contents().getName());
+    assertThat(results.getContent().get(0).isPinned()).isEqualTo(true);
+    assertThat(results.getContent().get(1).isPinned()).isEqualTo(false);
   }
 
   @Test
@@ -394,6 +396,8 @@ class ExhibitServiceTest {
     assertThat(results.getNumber()).isEqualTo(0);
     assertThat(results.getContent().get(0).getId()).isEqualTo(exhibit.getId());
     assertThat(results.getContent().get(0).getName()).isEqualTo(exhibit.contents().getName());
+    assertThat(results.getContent().get(0).isPinned()).isEqualTo(true);
+    assertThat(results.getContent().get(1).isPinned()).isEqualTo(false);
   }
 
   @Test


### PR DESCRIPTION
# 구현 내용

## 구현 요약

아래 API의 PostDetailInfo DTO에 상단 고정 여부 필드 isPinned(boolean)를 추가함
- [GET] /post/home : 홈화면 전시 목록 조회
- [GET] /post/home/{id} : 홈화면 - 특정 카테고리 전시 목록 조회
- [GET] /post/detail/{id} : 전시 상세 정보 조회

## 관련 이슈

close #112 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




