### PR TITLE
월별 전시 조회 API 응답값 수정

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
+++ b/src/main/java/com/yapp/artie/domain/archive/dto/exhibit/CalendarExhibitResponseDto.java
@@ -1,6 +1,7 @@
 package com.yapp.artie.domain.archive.dto.exhibit;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -10,17 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CalendarExhibitResponseDto {
 
-  @NonNull
-  @Schema(description = "연도(year)", required = true)
-  private final int year;
-
-  @NonNull
-  @Schema(description = "월(month)", required = true)
-  private final int month;
-
-  @NonNull
-  @Schema(description = "일(day)", required = true)
-  private final int day;
+  @Schema(description = "관람 날짜", required = true)
+  private final LocalDate postDate;
 
   @NonNull
   @Schema(description = "전시 ID", required = true)

--- a/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ExhibitService.java
@@ -211,8 +211,7 @@ public class ExhibitService {
   private CalendarExhibitResponseDto buildCalendarExhibitInformation(
       CalenderQueryResultDto queryResult) {
     LocalDate date = LocalDate.parse(queryResult.getCalenderDate(), DateTimeFormatter.ISO_DATE);
-    return new CalendarExhibitResponseDto(date.getYear(),
-        date.getMonthValue(), date.getDayOfMonth(), queryResult.getPostId(),
+    return new CalendarExhibitResponseDto(date, queryResult.getPostId(),
         s3Utils.getFullUri(queryResult.getUri()), queryResult.getPostNum());
   }
 

--- a/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
+++ b/src/main/java/com/yapp/artie/domain/user/controller/UserController.java
@@ -72,7 +72,7 @@ public class UserController {
   @GetMapping("/me")
   public ResponseEntity<User> me(Authentication authentication) {
 
-    Long userId = Long.parseLong(authentication.getName());
+    Long userId = getUserId(authentication);
     User user = userService.findById(userId);
 
     return ResponseEntity.ok().body(user);

--- a/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ExhibitServiceTest.java
@@ -230,12 +230,13 @@ class ExhibitServiceTest {
 
     assertThat(results.size()).isEqualTo(4);
     assertThat(results.get(0).getImageURL().endsWith("test-5")).isTrue();
-    assertThat(results.get(0).getYear()).isEqualTo(2023);
-    assertThat(results.get(0).getMonth()).isEqualTo(1);
-    assertThat(results.get(0).getDay()).isEqualTo(1);
+    assertThat(results.get(0).getPostDate().getYear()).isEqualTo(2023);
+    assertThat(results.get(0).getPostDate().getMonthValue()).isEqualTo(1);
+    assertThat(results.get(0).getPostDate().getDayOfMonth()).isEqualTo(1);
     assertThat(results.get(0).getPostNum()).isEqualTo(2);
     assertThat(results.get(0).getPostId()).isEqualTo(5L);
-    assertThat(results.get(1).getDay()).isEqualTo(2);
+    assertThat(results.get(0).getPostDate().toString()).isEqualTo("2023-01-01");
+    assertThat(results.get(1).getPostDate().getDayOfMonth()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
# 구현 내용

## 구현 요약

아래 경로의 API에서 사용하는 CalendarExhibitResponseDto에서 기존 year, month, day 필드가 제거되고, `yyyy-mm-dd` 포맷의 postDate 필드를 추가함

- [GET] /post/monthly : 월별 전시 조회


## 관련 이슈

#115 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)




