### PR TITLE
Revert "전시 페이지네이션 카운트 쿼리 수정"

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -43,7 +43,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
           + "where e.user = :user "
           + "and e.category = :category "
           + "and e.publication.isPublished = true",
-      countQuery = "select count(e.id) from Exhibit e where e.publication.isPublished = true"
+      countQuery = "select count(e.id) from Exhibit e"
   )
   Page<Exhibit> findExhibitByCategoryAsPage(Pageable pageable, @Param("user") UserJpaEntity user,
       @Param("category") Category category);
@@ -52,7 +52,7 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
       value = "select e from Exhibit e "
           + "where e.user = :user "
           + "and e.publication.isPublished = true",
-      countQuery = "select count(e.id) from Exhibit e where e.publication.isPublished = true"
+      countQuery = "select count(e.id) from Exhibit e"
   )
   Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") UserJpaEntity user);
 


### PR DESCRIPTION
## revert 사유
페이지 네이션 카운트 쿼리에서 categoryId와 userId가 포함되어야 함

## 관련 이슈

Reverts YAPP-Github/21st-ALL-Rounder-Team-2-BE#123