### PR TITLE
re: 전시 페이지네이션 카운트 쿼리 수정

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/ExhibitRepository.java
@@ -43,7 +43,9 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
           + "where e.user = :user "
           + "and e.category = :category "
           + "and e.publication.isPublished = true",
-      countQuery = "select count(e.id) from Exhibit e"
+      countQuery = "select count(e.id) from Exhibit e "
+          + "where e.publication.isPublished = true "
+          + "and e.category = :category"
   )
   Page<Exhibit> findExhibitByCategoryAsPage(Pageable pageable, @Param("user") UserJpaEntity user,
       @Param("category") Category category);
@@ -52,7 +54,9 @@ public interface ExhibitRepository extends JpaRepository<Exhibit, Long> {
       value = "select e from Exhibit e "
           + "where e.user = :user "
           + "and e.publication.isPublished = true",
-      countQuery = "select count(e.id) from Exhibit e"
+      countQuery = "select count(e.id) from Exhibit e "
+          + "where e.publication.isPublished = true "
+          + "and e.user = :user"
   )
   Page<Exhibit> findExhibitAsPage(Pageable pageable, @Param("user") UserJpaEntity user);
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

홈 화면 전시 조회에서 페이지네이션을 할 경우, last true가 제대로 출력이 안되는 버그가 있었음. 원인은 count 쿼리에서 isPublished가 누락 되어 발생했음.

## 관련 이슈

#122 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




