### PR TITLE
테스트 유저 토큰 발급 API 추가

### DIFF
--- a/src/main/java/com/yapp/artie/domain/user/adapter/in/web/GetTestUserTokenController.java
+++ b/src/main/java/com/yapp/artie/domain/user/adapter/in/web/GetTestUserTokenController.java
@@ -1,0 +1,34 @@
+package com.yapp.artie.domain.user.adapter.in.web;
+
+import com.yapp.artie.domain.user.application.port.in.GetTestUserTokenQuery;
+import com.yapp.artie.domain.user.application.port.in.GetTestUserTokenResponse;
+import com.yapp.artie.global.common.annotation.WebAdapter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+// TODO: 추후 서비스 QA 기간 종료된 이후, 개발 서버에만 공개하거나, 삭제해야함
+@WebAdapter
+@RequestMapping("/user")
+@RequiredArgsConstructor
+class GetTestUserTokenController {
+
+  private final GetTestUserTokenQuery getTestUserTokenQuery;
+
+  @Operation(summary = "테스트 유저 토큰 발급 API", description = "테스트 유저에 대한 Firebase Custom Token을 발급하여 반환함")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "테스트 유저에 대한 Firebase Custom Token을 성공적으로 발급하여 반환함")
+  })
+  @GetMapping("/test/token")
+  public ResponseEntity<GetTestUserTokenResponse> getTestUserToken() {
+    Long userId = 1L;
+    String token = getTestUserTokenQuery.loadTestUserToken(userId);
+    return ResponseEntity.ok().body(new GetTestUserTokenResponse(token));
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/user/adapter/out/authentication/FirebaseAuthenticationAdapter.java
+++ b/src/main/java/com/yapp/artie/domain/user/adapter/out/authentication/FirebaseAuthenticationAdapter.java
@@ -1,6 +1,7 @@
 package com.yapp.artie.domain.user.adapter.out.authentication;
 
 import com.yapp.artie.domain.user.application.port.out.DeleteExternalUserPort;
+import com.yapp.artie.domain.user.application.port.out.GenerateTestTokenPort;
 import com.yapp.artie.domain.user.application.port.out.TokenParsingPort;
 import com.yapp.artie.domain.user.domain.ArtieToken;
 import com.yapp.artie.global.common.annotation.AuthenticationAdapter;
@@ -10,11 +11,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @AuthenticationAdapter
 @RequiredArgsConstructor
-class FirebaseAuthenticationAdapter implements DeleteExternalUserPort, TokenParsingPort {
+class FirebaseAuthenticationAdapter implements DeleteExternalUserPort, TokenParsingPort,
+    GenerateTestTokenPort {
 
   private final FirebaseUserRemover firebaseUserRemover;
   private final JwtDecoder decoder;
   private final TokenGenerator tokenGenerator;
+  private final FirebaseTokenGenerator firebaseTokenGenerator;
 
   @Override
   public ArtieToken parseToken(String header) {
@@ -41,5 +44,10 @@ class FirebaseAuthenticationAdapter implements DeleteExternalUserPort, TokenPars
     }
 
     return header;
+  }
+
+  @Override
+  public String generateTestToken(String uid) {
+    return firebaseTokenGenerator.generate(uid);
   }
 }

--- a/src/main/java/com/yapp/artie/domain/user/adapter/out/authentication/FirebaseTokenGenerator.java
+++ b/src/main/java/com/yapp/artie/domain/user/adapter/out/authentication/FirebaseTokenGenerator.java
@@ -1,0 +1,35 @@
+package com.yapp.artie.domain.user.adapter.out.authentication;
+
+import com.google.firebase.auth.AbstractFirebaseAuth;
+import com.google.firebase.auth.AuthErrorCode;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.yapp.artie.global.common.exception.BusinessException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class FirebaseTokenGenerator {
+
+  private final AbstractFirebaseAuth firebaseAuth;
+
+  public String generate(String uid) {
+    try {
+      return firebaseAuth.createCustomToken(uid);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidFirebaseUidException();
+    } catch (FirebaseAuthException e) {
+      throw processRemoveException(e);
+    }
+  }
+
+  private BusinessException processRemoveException(FirebaseAuthException e) {
+    if (Objects.requireNonNull(e.getAuthErrorCode()) == AuthErrorCode.USER_NOT_FOUND) {
+      return new FirebaseUserNotFoundException();
+    }
+
+    return new InvalidFirebaseUidException();
+  }
+}
+

--- a/src/main/java/com/yapp/artie/domain/user/application/port/in/GetTestUserTokenQuery.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/port/in/GetTestUserTokenQuery.java
@@ -1,0 +1,6 @@
+package com.yapp.artie.domain.user.application.port.in;
+
+public interface GetTestUserTokenQuery {
+
+  String loadTestUserToken(Long userId);
+}

--- a/src/main/java/com/yapp/artie/domain/user/application/port/in/GetTestUserTokenResponse.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/port/in/GetTestUserTokenResponse.java
@@ -1,0 +1,14 @@
+package com.yapp.artie.domain.user.application.port.in;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "테스트 유저 토큰 발급 Response")
+@RequiredArgsConstructor
+public class GetTestUserTokenResponse {
+
+  @Schema(description = "테스트 유저 토큰")
+  private final String token;
+}

--- a/src/main/java/com/yapp/artie/domain/user/application/port/out/GenerateTestTokenPort.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/port/out/GenerateTestTokenPort.java
@@ -1,0 +1,6 @@
+package com.yapp.artie.domain.user.application.port.out;
+
+public interface GenerateTestTokenPort {
+
+  String generateTestToken(String uid);
+}

--- a/src/main/java/com/yapp/artie/domain/user/application/service/GetTestUserTokenService.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/service/GetTestUserTokenService.java
@@ -1,0 +1,23 @@
+package com.yapp.artie.domain.user.application.service;
+
+import com.yapp.artie.domain.user.application.port.in.GetTestUserTokenQuery;
+import com.yapp.artie.domain.user.application.port.out.GenerateTestTokenPort;
+import com.yapp.artie.domain.user.application.port.out.LoadUserPort;
+import com.yapp.artie.global.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+class GetTestUserTokenService implements GetTestUserTokenQuery {
+
+  private final LoadUserPort loadUserPort;
+  private final GenerateTestTokenPort generateTestTokenPort;
+
+  @Override
+  public String loadTestUserToken(Long userId) {
+    String uid = loadUserPort.loadById(userId).getUid();
+    return generateTestTokenPort.generateTestToken(uid);
+  }
+}

--- a/src/main/java/com/yapp/artie/global/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/artie/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/")
         .antMatchers("/swagger-ui/**")
         .antMatchers("/v3/api-docs/**")
-        .antMatchers("/resources/**");
+        .antMatchers("/resources/**")
+        .antMatchers("/user/test/token");
   }
 }

--- a/src/test/java/com/yapp/artie/domain/user/adapter/in/web/GetTestUserTokenControllerTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/adapter/in/web/GetTestUserTokenControllerTest.java
@@ -1,0 +1,33 @@
+package com.yapp.artie.domain.user.adapter.in.web;
+
+import static com.yapp.artie.common.UserTestData.defaultUser;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.yapp.artie.common.BaseControllerIntegrationTest;
+import com.yapp.artie.domain.user.application.port.in.GetTestUserTokenQuery;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(controllers = GetTestUserTokenController.class)
+class GetTestUserTokenControllerTest extends BaseControllerIntegrationTest {
+
+  @MockBean
+  private GetTestUserTokenQuery getTestUserTokenQuery;
+
+  @Test
+  void testGetTestUserTokenQuery() throws Exception {
+    givenUserByReference(defaultUser().withId(1L).build());
+
+    mvc.perform(get("/user/test/token")
+            .header("Content-Type", "application/json")
+        )
+        .andExpect(status().isOk());
+
+    then(getTestUserTokenQuery).should()
+        .loadTestUserToken(eq(1L));
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/user/adapter/out/authentication/FirebaseAuthenticationAdapterTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/adapter/out/authentication/FirebaseAuthenticationAdapterTest.java
@@ -20,8 +20,11 @@ class FirebaseAuthenticationAdapterTest {
   private final JwtDecoder jwtDecoder = Mockito.mock(JwtDecoder.class);
   private final FirebaseUserRemover firebaseUserRemover = Mockito.mock(FirebaseUserRemover.class);
   private final TokenGenerator tokenGenerator = Mockito.mock(TokenGenerator.class);
+  private final FirebaseTokenGenerator firebaseTokenGenerator = Mockito.mock(
+      FirebaseTokenGenerator.class);
   private final FirebaseAuthenticationAdapter adapterUnderTest =
-      new FirebaseAuthenticationAdapter(firebaseUserRemover, jwtDecoder, tokenGenerator);
+      new FirebaseAuthenticationAdapter(firebaseUserRemover, jwtDecoder, tokenGenerator,
+          firebaseTokenGenerator);
 
   @Test
   void parseToken_헤더가_null인_경우_예외를_발생한다() {
@@ -76,6 +79,12 @@ class FirebaseAuthenticationAdapterTest {
     then(firebaseUserRemover)
         .should()
         .remove(eq("uid"));
+  }
+
+  @Test
+  public void generateTestToken_주어진_uid를_가지는_테스트유저의_FirebaseCustomToken발급을_요청한다() {
+    adapterUnderTest.generateTestToken("uid");
+    then(firebaseTokenGenerator).should().generate("uid");
   }
 
   private void givenArtieTokenByReference(User user) {

--- a/src/test/java/com/yapp/artie/domain/user/application/service/GetTestUserTokenServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/application/service/GetTestUserTokenServiceTest.java
@@ -1,0 +1,40 @@
+package com.yapp.artie.domain.user.application.service;
+
+import static com.yapp.artie.common.UserTestData.defaultUser;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+
+import com.yapp.artie.common.BaseUserUnitTest;
+import com.yapp.artie.domain.user.application.port.out.GenerateTestTokenPort;
+import com.yapp.artie.domain.user.domain.User;
+import com.yapp.artie.domain.user.domain.UserNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class GetTestUserTokenServiceTest extends BaseUserUnitTest {
+
+  private final GenerateTestTokenPort generateTestTokenPort = Mockito.mock(
+      GenerateTestTokenPort.class);
+
+  private final GetTestUserTokenService getTestUserTokenService = new GetTestUserTokenService(
+      loadUserPort, generateTestTokenPort);
+
+  @Test
+  void loadTestUserToken_사용자를_찾을_수_없으면_예외를_발생한다() {
+    givenUserFindWillFail();
+    assertThatThrownBy(() -> getTestUserTokenService.loadTestUserToken(1L))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  void loadTestUserToken_사용자를_조회하여_토큰을_발급한다() {
+    User user = defaultUser().build();
+    givenUserByReference(user);
+
+    getTestUserTokenService.loadTestUserToken(1L);
+    then(generateTestTokenPort)
+        .should()
+        .generateTestToken(eq(user.getUid()));
+  }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 테스트 유저 토큰 발급 API 추가
- Controller, Service, Query, Port 추가
- FirebaseAdapter 수정
- 테스트 유저 토큰 발급에 대한 테스트 추가

## 관련 이슈

close #127 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




