### PR TITLE
유저 조회 API 추가

### DIFF
--- a/src/main/java/com/yapp/artie/domain/user/adapter/in/web/GetUserJoinDateController.java
+++ b/src/main/java/com/yapp/artie/domain/user/adapter/in/web/GetUserJoinDateController.java
@@ -1,0 +1,41 @@
+package com.yapp.artie.domain.user.adapter.in.web;
+
+import com.yapp.artie.domain.user.application.port.in.GetUserJoinDateQuery;
+import com.yapp.artie.domain.user.application.port.in.GetUserJoinDateResponse;
+import com.yapp.artie.global.common.annotation.WebAdapter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@WebAdapter
+@RequestMapping("/user")
+@RequiredArgsConstructor
+class GetUserJoinDateController {
+
+  private final GetUserJoinDateQuery getUserJoinDateQuery;
+
+  @Operation(summary = "유저 가입일 조회", description = "유저 가입일(createdAt) 조회")
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "유저 가입일을 성공적으로 조회함")})
+  @GetMapping("/join")
+  public ResponseEntity<GetUserJoinDateResponse> getUserJoinDate(Authentication authentication) {
+    Long userId = getUserId(authentication);
+    LocalDateTime joinDate = getUserJoinDateQuery.loadUserJoinDate(userId);
+
+    return ResponseEntity.ok().body(new GetUserJoinDateResponse(joinDate));
+  }
+
+  // TODO : 앱 배포했을 때에는 1L 대신에 exception을 던지도록 변경해야 합니다.
+  private Long getUserId(Authentication authentication) {
+    if (Optional.ofNullable(authentication).isPresent()) {
+      return Long.parseLong(authentication.getName());
+    }
+    return 1L;
+  }
+}

--- a/src/main/java/com/yapp/artie/domain/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/yapp/artie/domain/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -7,6 +7,7 @@ import com.yapp.artie.domain.user.application.port.out.UpdateUserStatePort;
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.domain.UserNotFoundException;
 import com.yapp.artie.global.common.annotation.PersistenceAdapter;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -25,6 +26,11 @@ class UserPersistenceAdapter implements DeleteUserPort, SaveUserPort, LoadUserPo
   @Override
   public User loadByUid(String uid) {
     return userMapper.mapToDomainEntity(findByUidOrElseThrow(uid));
+  }
+
+  @Override
+  public LocalDateTime loadJoinDateById(Long userId) {
+    return findByIdOrElseThrow(userId).getCreatedAt();
   }
 
   @Override

--- a/src/main/java/com/yapp/artie/domain/user/application/port/in/GetUserJoinDateQuery.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/port/in/GetUserJoinDateQuery.java
@@ -1,0 +1,8 @@
+package com.yapp.artie.domain.user.application.port.in;
+
+import java.time.LocalDateTime;
+
+public interface GetUserJoinDateQuery {
+
+  LocalDateTime loadUserJoinDate(Long userId);
+}

--- a/src/main/java/com/yapp/artie/domain/user/application/port/in/GetUserJoinDateResponse.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/port/in/GetUserJoinDateResponse.java
@@ -1,0 +1,15 @@
+package com.yapp.artie.domain.user.application.port.in;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "유저 가입일 조회 Response")
+@RequiredArgsConstructor
+public class GetUserJoinDateResponse {
+
+  @Schema(description = "유저 가입일")
+  private final LocalDateTime joinDate;
+}

--- a/src/main/java/com/yapp/artie/domain/user/application/port/out/LoadUserPort.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/port/out/LoadUserPort.java
@@ -1,10 +1,13 @@
 package com.yapp.artie.domain.user.application.port.out;
 
 import com.yapp.artie.domain.user.domain.User;
+import java.time.LocalDateTime;
 
 public interface LoadUserPort {
 
   User loadById(Long userId);
 
   User loadByUid(String uid);
+
+  LocalDateTime loadJoinDateById(Long userId);
 }

--- a/src/main/java/com/yapp/artie/domain/user/application/service/GetUserJoinDateService.java
+++ b/src/main/java/com/yapp/artie/domain/user/application/service/GetUserJoinDateService.java
@@ -1,0 +1,21 @@
+package com.yapp.artie.domain.user.application.service;
+
+import com.yapp.artie.domain.user.application.port.in.GetUserJoinDateQuery;
+import com.yapp.artie.domain.user.application.port.out.LoadUserPort;
+import com.yapp.artie.global.common.annotation.UseCase;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+class GetUserJoinDateService implements GetUserJoinDateQuery {
+
+  private final LoadUserPort loadUserPort;
+
+  @Override
+  public LocalDateTime loadUserJoinDate(Long userId) {
+    return loadUserPort.loadJoinDateById(userId);
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/user/adapter/in/web/GetUserJoinDateControllerTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/adapter/in/web/GetUserJoinDateControllerTest.java
@@ -1,0 +1,35 @@
+package com.yapp.artie.domain.user.adapter.in.web;
+
+import static com.yapp.artie.common.UserTestData.defaultUser;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.yapp.artie.common.BaseControllerIntegrationTest;
+import com.yapp.artie.domain.user.application.port.in.GetUserJoinDateQuery;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(controllers = GetUserJoinDateController.class)
+class GetUserJoinDateControllerTest extends BaseControllerIntegrationTest {
+
+  @MockBean
+  private GetUserJoinDateQuery getUserJoinDateQuery;
+
+  @Test
+  void getUserJoinDate() throws Exception {
+    givenUserByReference(defaultUser()
+        .withName("tomcat")
+        .build());
+
+    mvc.perform(get("/user/join")
+        .header("Content-Type", "application/json")
+        .header("Authorization", "sample")
+    ).andExpect(status().isOk());
+
+    then(getUserJoinDateQuery).should()
+        .loadUserJoinDate(eq(1L));
+  }
+}

--- a/src/test/java/com/yapp/artie/domain/user/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yapp.artie.domain.user.domain.User;
 import com.yapp.artie.domain.user.domain.UserNotFoundException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -55,6 +56,20 @@ class UserPersistenceAdapterTest {
 
   @Test
   @Sql("UserPersistenceAdapterTest.sql")
+  void loadJoinDateById_id를_이용해서_사용자_조회() {
+    LocalDateTime joinDate = adapterUnderTest.loadJoinDateById(1L);
+    assertThat(joinDate).isEqualTo(LocalDateTime.of(2023, 2, 4, 21, 58, 50));
+  }
+
+  @Test
+  void loadJoinDateById_사용자를_찾을_수_없으면_예외를_발생한다() {
+    assertThatThrownBy(() -> {
+      adapterUnderTest.loadJoinDateById(1L);
+    }).isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  @Sql("UserPersistenceAdapterTest.sql")
   void delete_사용자를_데이터베이스에서_삭제한다() {
     adapterUnderTest.delete(adapterUnderTest.loadById(1L));
 
@@ -85,9 +100,7 @@ class UserPersistenceAdapterTest {
 
     adapterUnderTest.updateName(user);
 
-    String actual = userRepository.findById(1L)
-        .orElseThrow()
-        .getName();
+    String actual = userRepository.findById(1L).orElseThrow().getName();
     assertThat(actual).isEqualTo("tomcat");
   }
 

--- a/src/test/java/com/yapp/artie/domain/user/application/service/GetUserJoinDateServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/user/application/service/GetUserJoinDateServiceTest.java
@@ -1,0 +1,45 @@
+package com.yapp.artie.domain.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.yapp.artie.domain.user.application.port.out.LoadUserPort;
+import com.yapp.artie.domain.user.domain.UserNotFoundException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class GetUserJoinDateServiceTest {
+
+  protected final LoadUserPort loadUserPort = Mockito.mock(LoadUserPort.class);
+
+  private final GetUserJoinDateService getUserJoinDateService = new GetUserJoinDateService(
+      loadUserPort);
+
+  @Test
+  void loadUserJoinDate_사용자를_찾을_수_없으면_예외를_발생한다() {
+    givenUserJoinDateFindWillFail();
+    assertThatThrownBy(() -> getUserJoinDateService.loadUserJoinDate(1L))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  void loadUserJoinDate_사용자를_조회한다() {
+    LocalDateTime now = LocalDateTime.now();
+    givenUserByDate(now);
+    LocalDateTime joinDate = getUserJoinDateService.loadUserJoinDate(1L);
+    assertThat(joinDate).isEqualTo(now);
+  }
+
+  private void givenUserJoinDateFindWillFail() {
+    given(loadUserPort.loadJoinDateById(any()))
+        .willThrow(UserNotFoundException.class);
+  }
+
+  private void givenUserByDate(LocalDateTime date) {
+    given(loadUserPort.loadJoinDateById(any()))
+        .willReturn(date);
+  }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 유저 조회 API 추가
  - 컨트롤러, 서비스, Response, Query 추가
  - LoadUserPort 인터페이스에 loadUserJoinDate 메소드 추가
  - UserPersistenceAdapter 클래스에 loadUserJoinDate 메소드 추가

## 관련 이슈

close #131 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




