### PR TITLE
이미 대표 작품으로 설정되어 있는 작품에 대해 대표 작품 등록을 요청할 경우, 대표 설정이 해제되는 버그 해결

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/ArtworkService.java
@@ -133,8 +133,10 @@ public class ArtworkService {
   @Transactional
   public void setMainArtwork(Long artworkId, Long userId) {
     Artwork artwork = findById(artworkId, userId);
-    artworkRepository.updateArtworkNotMainByExhibit(artwork.getExhibit());
-    artwork.setMainArtwork();
+    if (!artwork.isMain()) {
+      artworkRepository.updateArtworkNotMainByExhibit(artwork.getExhibit());
+      artwork.setMainArtwork();
+    }
   }
 
   private ArtworkThumbnailDto buildArtworkThumbnail(Artwork artwork) {

--- a/src/test/java/com/yapp/artie/domain/archive/service/ArtworkServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/ArtworkServiceTest.java
@@ -206,5 +206,25 @@ class ArtworkServiceTest {
     assertThat(newArtworks.get(0).getId()).isEqualTo(artworks.get(2).getId());
     assertThat(newArtworks.get(0).isMain()).isFalse();
   }
+
+  @Test
+  @DisplayName("대표 작품이었던 작품에 대해 대표 작품을 설정하려는 요청이 있어도, 정상적으로 대표 작품 상태를 유지해야합니다.")
+  public void setMainArtwork_이미_대표_작품을_대표_작품으로_설정() {
+    UserJpaEntity user = createUser("user", "tu");
+    Category defaultCategory = categoryRepository.findCategoryEntityGraphById(user.getId());
+    Exhibit exhibit = exhibitRepository.save(
+        Exhibit.create("test", LocalDate.now(), defaultCategory, user, null));
+    artworkRepository.save(Artwork.create(exhibit, true, "sample-uri")).getId();
+    em.flush();
+    em.clear();
+
+    artworkService.setMainArtwork(1L, user.getId());
+    em.flush();
+    em.clear();
+
+    Artwork updatedArtwork = em.find(Artwork.class, 1L);
+
+    assertThat(updatedArtwork.isMain()).isTrue();
+  }
 }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 이미 대표 작품으로 설정되어 있는 작품에 대해 대표 작품 등록을 요청할 경우, 대표 설정이 해제되는 버그 해결
- 이미 대표 작품으로 설정되어 있을 경우, 추가적인 로직을 수행하지 않도록 처리함

## 원인
```java
@Transactional
public void setMainArtwork(Long artworkId, Long userId) {
  Artwork artwork = findById(artworkId, userId); //1
  artworkRepository.updateArtworkNotMainByExhibit( artwork.getExhibit()); //2
  artwork.setMainArtwork(); //3
}
```
위 코드는 대표 작품으로 설정하는 서비스 메소드입니다.
주어진 작품 ID를 통해 작품을 찾고(1), 
해당 작품으로 부터 전시를 확인해 그 전시에 등록된 작품 중 대표 작품으로 등록되어있던 작품을 대표 설정 해제 하고(2),
주어진 작품은 대표 작품으로 설정합니다. (3)

더 자세하게 쿼리와 영속성 컨텍스트 방면에서 설명하도록 하겠습니다.
1. 주어진 작품을 찾습니다.
2. `artworkRepository.updateArtworkNotMainByExhibit` 메소드를 통해, 기존에 등록된 대표 작품을 대표 해제하는 벌크성 쿼리를 수행합니다.
   1. 벌크성 쿼리는 즉시 실행되며, 이후에 영속성 컨텍스를 flush합니다.
   2. 벌크성 쿼리는 즉시 실행되므로, 주어진 작품은 이제 **DB 상에서는** 대표 해제, 즉 isMain = false 값을 가집니다.
3. `artwork.setMainArtwork` 메소드를 통해, 주어진 작품을 대표로 등록합니다. 즉, isMain = true 처리를 합니다.
4. 서비스 로직이 종료됨에 따라, 영속성 컨텍스트를 flush합니다.
   1. 이때, 3번에서 처리한 isMain = true가 반영되어야하지만, 반영되지 않습니다.
   2. DB 상에서는 isMain = false 이지만, 영속성 컨텍스트의 1차 캐시는 아직 isMain = true이기 때문입니다. 2번 과정에서 영속성 컨텍스트가 flush되었지만, clear되는 1차 캐시가 비워지는 행위는 수행하지 않았기에 isMain = true로 유지됩니다.
   3. 따라서, 1차 캐시에 저장된 이 작품은 isMain = true인 상태이기에, dirty checking 결과 변경사항이 없어 별도의 쿼리가 수행되지 않습니다.

### ❗  따라서 이 서비스에서는 Update 쿼리는 벌크성 쿼리 외에는 수행되지 않았으므로, 기존에 대표로 설정되었던 작품에 대해 이 서비스 메소드를 수행할 경우, 대표 등록이 해제됩니다.

## 관련 이슈

close #133 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




