### PR TITLE
카테고리 순서 변경 불가 버그 수정

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
+++ b/src/main/java/com/yapp/artie/domain/archive/repository/CategoryRepository.java
@@ -30,5 +30,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   @Modifying(clearAutomatically = true)
   void deleteAllByUser(UserJpaEntity user);
+
+  List<Category> findCategoriesByUser(UserJpaEntity userJpaEntity);
 }
 

--- a/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
@@ -80,15 +80,16 @@ public class CategoryService {
   @Transactional
   public void shuffle(List<CategoryDto> changeCategorySequenceDtos, Long userId) {
     UserJpaEntity user = findUser(userId);
-    List<Category> categories = categoryRepository.findCategoriesByUserOrderBySequence(user);
+    List<Category> categories = categoryRepository.findCategoriesByUser(user);
     validateChangeCategoriesLengthWithOriginal(changeCategorySequenceDtos, categories);
 
-    int sequence = 0;
     for (CategoryDto changeCategorySequenceDto : changeCategorySequenceDtos) {
-      int originSequence = changeCategorySequenceDto.getSequence();
-      Category category = categories.get(originSequence);
-
-      category.rearrange(sequence++);
+      categoryRepository.findById(changeCategorySequenceDto.getId())
+          .ifPresent(value -> {
+            if (value.ownedBy(user)) {
+              value.rearrange(changeCategorySequenceDto.getSequence());
+            }
+          });
     }
   }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [PUT] /category/sequence 요청시, Request Body로 넘겨주는 CategoryDto에 sequence값을 변경된 순서값으로 넘겨줘 index out of error가 발생함
   - 기존 로직은, Request Body에 넘겨주는 CategoryDto에 넘겨주는 sequence 값이 기존의 값이며, 변경된 배열의 순서는 Request Body에 담긴 배열 내의 CategoryDto 순서를 바탕으로 순서를 조정하였음
   - 따라서, Request Body로 넘겨주는 CategoryDto에 sequence값을 변경된 순서값으로 받도록 처리함

## 관련 이슈

close #136 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)




