### PR TITLE
카테고리 목록 조회시, 카테고리가 없으면 404 에러 발생

### DIFF
--- a/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
+++ b/src/main/java/com/yapp/artie/domain/archive/service/CategoryService.java
@@ -40,13 +40,10 @@ public class CategoryService {
   }
 
   public List<CategoryDto> categoriesOf(Long userId) {
-    UserJpaEntity user = findUser(userId);
-    List<CategoryDto> categories = categoryRepository.findCategoriesByUserOrderBySequence(user)
-        .stream().map(this::buildCategoryDto).collect(
-            Collectors.toList());
-    validateExistAtLeastOneCategory(categories);
-
-    return categories;
+    return categoryRepository.findCategoriesByUserOrderBySequence(findUser(userId))
+        .stream()
+        .map(this::buildCategoryDto)
+        .collect(Collectors.toList());
   }
 
   @Transactional
@@ -108,12 +105,6 @@ public class CategoryService {
 
   private int getSequence(UserJpaEntity user) {
     return categoryRepository.countCategoriesByUser(user);
-  }
-
-  private void validateExistAtLeastOneCategory(List<CategoryDto> categories) {
-    if (categories.size() == 0) {
-      throw new CategoryNotFoundException();
-    }
   }
 
   private void validateDuplicateCategory(String name, UserJpaEntity user) {

--- a/src/test/java/com/yapp/artie/domain/archive/service/CategoryServiceTest.java
+++ b/src/test/java/com/yapp/artie/domain/archive/service/CategoryServiceTest.java
@@ -139,10 +139,9 @@ class CategoryServiceTest {
   }
 
   @Test
-  public void categoriesOf_카테고리가_하나도_존재하지_않으면_예외를_발생한다() throws Exception {
-    assertThatThrownBy(() -> {
-      categoryService.categoriesOf(findUser("1").getId());
-    }).isInstanceOf(CategoryNotFoundException.class);
+  public void categoriesOf_카테고리가_하나도_존재하지_않는다면_빈_리스트를_반환한다() throws Exception {
+    List<CategoryDto> actual = categoryService.categoriesOf(findUser("1").getId());
+    assertThat(actual.size()).isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [GET] /category : 카테고리 목록 조회
    - 기존 로직은 사용자의 카테고리가 존재하지 않다면 404 에러를 발생
    - emptyList를 반환하도록 기능 수정

## 관련 이슈

#143 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)




